### PR TITLE
replaced deprecated functions boundary_indicator + cosmesis

### DIFF
--- a/apps/conv-table.cc
+++ b/apps/conv-table.cc
@@ -351,7 +351,7 @@ namespace ConvTables
         for (unsigned int face_number=0; face_number<GeometryInfo<dim>::faces_per_cell; ++face_number)
           if (cell->face(face_number)->at_boundary()
               &&
-              (cell->face(face_number)->boundary_indicator() == 1))
+              (cell->face(face_number)->boundary_id() == 1))
             {
               fe_face_values.reinit (cell, face_number);
 
@@ -481,7 +481,7 @@ namespace ConvTables
                 if ((std::fabs(cell->face(face_number)->center()(0) - (-1)) < 1e-12)
                     ||
                     (std::fabs(cell->face(face_number)->center()(1) - (-1)) < 1e-12))
-                  cell->face(face_number)->set_boundary_indicator (1);
+                  cell->face(face_number)->set_boundary_id (1);
           }
         else
           refine_grid ();

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -45,7 +45,7 @@ namespace
     int status = -4; // some arbitrary value to eliminate the compiler warning
     handle result( abi::__cxa_demangle(name, NULL, NULL, &status) );
     return (status==0) ? result.p : name ;
-  };
+  }
 }
 
 /**
@@ -55,6 +55,6 @@ template <class T>
 std::string type(const T &t)
 {
   return demangle(typeid(t).name());
-};
+}
 
 #endif

--- a/source/parameter_acceptor.cc
+++ b/source/parameter_acceptor.cc
@@ -133,4 +133,4 @@ void ParameterAcceptor::parse_parameters(ParameterHandler &prm)
 }
 
 
-void ParameterAcceptor::parse_parameters_call_back() {};
+void ParameterAcceptor::parse_parameters_call_back() {}


### PR DESCRIPTION
boundary_indicator() è stata deprecata 
ho tolto un paio di ; per avere un output pulito quando si fa il make
