### PR TITLE
fix find external libraries

### DIFF
--- a/cmake/macros/macro_configure_feature.cmake
+++ b/cmake/macros/macro_configure_feature.cmake
@@ -195,14 +195,6 @@ MACRO(CONFIGURE_FEATURE _feature)
   ENDFOREACH()
 
   #
-  # Obey the user overrides:
-  #
-  IF( (NOT DEFINED D2K_WITH_${_feature}) )
-    PURGE_FEATURE(${_feature})
-    SET_CACHED_OPTION(${_feature} OFF)
-  ENDIF()
-
-  #
   # Only try to configure ${_feature} if we have to, i.e.
   # D2K_WITH_${_feature} is set to true or not set at all.
   #


### PR DESCRIPTION
now if the `FEATURE_DIR` is set in the environment, `FEATURE` it is automatically detected
