### PR TITLE
fixed cmake default build type

### DIFF
--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -92,11 +92,11 @@ OPTION(D2K_ENABLE_TESTING
 #
 # Setup CMAKE_BUILD_TYPE:
 #
-
 SET(CMAKE_BUILD_TYPE
-  "DebugRelease"
+  ${DEAL_II_BUILD_TYPE}
   CACHE STRING
   "Choose the type of build, options are: Debug, Release and DebugRelease."
+  FORCE
   )
 
 # This is cruel, I know. But it is better to only have a known number of


### PR DESCRIPTION
I didn't realize that `CMAKE_BUILD_TYPE` was previously set by the macro `DEAL_II_INITIALIZE_CACHED_VARIABLES`
