### PR TITLE
fixed DebugRelease for external libraries

### DIFF
--- a/cmake/macros/macro_deal2lkit_initialize_cached_variables.cmake
+++ b/cmake/macros/macro_deal2lkit_initialize_cached_variables.cmake
@@ -57,17 +57,10 @@ MACRO(D2K_INITIALIZE_CACHED_VARIABLES)
   ENDIF()
 
   #
-  # Set build type according to available libraries
+  # Set build type according to build type of deal2lkit
   #
-  IF(D2K_BUILD_TYPE MATCHES "Debug")
-    SET(CMAKE_BUILD_TYPE "Debug" CACHE STRING
-      "Choose the type of build, options are: Debug, Release"
-      )
-  ELSE()
-    SET(CMAKE_BUILD_TYPE "Release" CACHE STRING
-      "Choose the type of build, options are: Debug, Release"
-      )
-  ENDIF()
+  SET(CMAKE_BUILD_TYPE ${D2K_BUILD_TYPE} CACHE STRING
+    "Choose the type of build, options are: Debug, Release, DebugRelease")
 
   #
   # Reset build type if unsupported, i.e. if it is not (case insensitively
@@ -77,26 +70,21 @@ MACRO(D2K_INITIALIZE_CACHED_VARIABLES)
 
   IF(NOT "${_cmake_build_type}" MATCHES "^(debug|release|debugrelease)$")
 
-    IF("${D2K_BUILD_TYPE}" STREQUAL "DebugRelease")
-      SET(_new_build_type "Debug")
-    ELSE()
-      SET(_new_build_type "${D2K_BUILD_TYPE}")
-    ENDIF()
 
     MESSAGE(
-      "###
-      #
-      #  WARNING:
-      #
-      #  CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\" unsupported by current installation!
-      #  deal2lkit was built with CMAKE_BUILD_TYPE \"${D2K_BUILD_TYPE}\".
-      #
-      #  CMAKE_BUILD_TYPE is forced to \"${_new_build_type}\".
-      #
-      ###"
+"###
+#
+#  WARNING:
+#
+#  CMAKE_BUILD_TYPE \"${CMAKE_BUILD_TYPE}\" unsupported by current installation!
+#  deal2lkit was built with CMAKE_BUILD_TYPE \"${D2K_BUILD_TYPE}\".
+#
+#  CMAKE_BUILD_TYPE is forced to \"${D2K_BUILD_TYPE}\".
+#
+###"
       )
-    SET(CMAKE_BUILD_TYPE "${_new_build_type}" CACHE STRING
-      "Choose the type of build, options are: Debug, Release"
+    SET(CMAKE_BUILD_TYPE ${D2K_BUILD_TYPE} CACHE STRING
+      "Choose the type of build, options are: Debug, Release, DebugRelease"
       FORCE
       )
 

--- a/cmake/macros/macro_deal2lkit_setup_target.cmake
+++ b/cmake/macros/macro_deal2lkit_setup_target.cmake
@@ -69,8 +69,6 @@
 
 MACRO(D2K_SETUP_TARGET _target)
 
-  DEAL_II_SETUP_TARGET(${_target})
-
   IF(NOT D2K_PROJECT_CONFIG_INCLUDED)
     MESSAGE(FATAL_ERROR
       "\nD2K_SETUP_TARGET can only be called in external projects after "
@@ -133,5 +131,7 @@ MACRO(D2K_SETUP_TARGET _target)
       LINK_SEARCH_END_STATIC TRUE
       )
   ENDIF()
+
+  DEAL_II_SETUP_TARGET(${_target})
 
 ENDMACRO()

--- a/cmake/setup_cached_variables.cmake
+++ b/cmake/setup_cached_variables.cmake
@@ -96,7 +96,6 @@ SET(CMAKE_BUILD_TYPE
   ${DEAL_II_BUILD_TYPE}
   CACHE STRING
   "Choose the type of build, options are: Debug, Release and DebugRelease."
-  FORCE
   )
 
 # This is cruel, I know. But it is better to only have a known number of


### PR DESCRIPTION
after PR https://github.com/dealii/dealii/pull/1758, the option `CMAKE_BUILD_TYPE=DebugRelease` can be used (and works out of the box) also for the external libraries based on `deal2lkit`
