### PR TITLE
fixed macro deal2lkit_setup_target

### DIFF
--- a/cmake/macros/macro_deal2lkit_setup_target.cmake
+++ b/cmake/macros/macro_deal2lkit_setup_target.cmake
@@ -132,6 +132,6 @@ MACRO(D2K_SETUP_TARGET _target)
       )
   ENDIF()
 
-  DEAL_II_SETUP_TARGET(${_target})
+  DEAL_II_SETUP_TARGET(${_target} ${ARGN})
 
 ENDMACRO()


### PR DESCRIPTION
this fixes the linking options when `CMAKE_BUILD_TYPE=DebugRelease`
