### PR TITLE
Remove template from functions.

### DIFF
--- a/doxygen/headers/changes.h
+++ b/doxygen/headers/changes.h
@@ -1,0 +1,85 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal2lkit authors
+//
+// This file is part of the deal2lkit library.
+//
+// The deal2lkit library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+/**
+@page changes_after_1_0_0 Changes after Version 1.0.0
+
+<p>
+This is the list of changes made after the release of \dk version
+1.0.0. All entries are signed with the names of the authors.
+</p>
+
+
+
+<!-- ----------- INCOMPATIBILITIES ----------------- -->
+
+<a name="incompatible"></a>
+<h3 style="color:red">Incompatibilities</h3>
+
+<p style="color:red">
+Following are a few modifications to the library that unfortunately
+are incompatible with previous versions of the library, but which we
+deem necessary for the future maintainability of the
+library. Unfortunately, some of these changes will require
+modifications to application programs. We apologize for the
+inconvenience this causes.
+</p>
+
+<ol> 
+
+<li> Changed: The ParsedFunction, ParsedMappedFunctions, and
+ParsedDirichletBCs used to have a template parameter specifying the
+number of components. This has been removed and the number of
+components is now specified at construction time. 
+(Luca Heltai, 2015/11/26)
+</li>
+
+
+</ol>
+
+
+<!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
+
+<a name="general"></a>
+<h3>General</h3>
+
+<ol>
+  <li> 
+  Empty.
+  <br>
+  (Empty XXXX/XX/XX)
+  </li>
+
+
+</ol>
+
+
+<!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
+
+<a name="specific"></a>
+<h3>Specific improvements</h3>
+
+
+<ol>
+  <li> 
+  Empty.
+  <br>
+  (Empty XXXX/XX/XX)
+  </li>
+
+
+</ol>
+
+*/

--- a/doxygen/headers/changes.h.empty
+++ b/doxygen/headers/changes.h.empty
@@ -1,0 +1,84 @@
+// ---------------------------------------------------------------------
+//
+// Copyright (C) 2015 by the deal2lkit authors
+//
+// This file is part of the deal2lkit library.
+//
+// The deal2lkit library is free software; you can use it, redistribute
+// it, and/or modify it under the terms of the GNU Lesser General
+// Public License as published by the Free Software Foundation; either
+// version 2.1 of the License, or (at your option) any later version.
+// The full text of the license can be found in the file LICENSE at
+// the top level of the deal.II distribution.
+//
+// ---------------------------------------------------------------------
+
+/**
+@page changes_after_X_X_X Changes after Version X.X.X
+
+<p>
+This is the list of changes made after the release of \dk version
+1.0.0. All entries are signed with the names of the authors.
+</p>
+
+
+
+<!-- ----------- INCOMPATIBILITIES ----------------- -->
+
+<a name="incompatible"></a>
+<h3 style="color:red">Incompatibilities</h3>
+
+<p style="color:red">
+Following are a few modifications to the library that unfortunately
+are incompatible with previous versions of the library, but which we
+deem necessary for the future maintainability of the
+library. Unfortunately, some of these changes will require
+modifications to application programs. We apologize for the
+inconvenience this causes.
+</p>
+
+<ol> 
+
+  <li> 
+  Empty.
+  <br>
+  (Empty XXXX/XX/XX)
+  </li>
+
+
+</ol>
+
+
+<!-- ----------- GENERAL IMPROVEMENTS ----------------- -->
+
+<a name="general"></a>
+<h3>General</h3>
+
+<ol>
+  <li> 
+  Empty.
+  <br>
+  (Empty XXXX/XX/XX)
+  </li>
+
+
+</ol>
+
+
+<!-- ----------- SPECIFIC IMPROVEMENTS ----------------- -->
+
+<a name="specific"></a>
+<h3>Specific improvements</h3>
+
+
+<ol>
+  <li> 
+  Empty.
+  <br>
+  (Empty XXXX/XX/XX)
+  </li>
+
+
+</ol>
+
+*/

--- a/examples/dynamic_stokes/include/stokes_ida.h
+++ b/examples/dynamic_stokes/include/stokes_ida.h
@@ -195,13 +195,13 @@ private:
   ParsedGridRefinement           pgr;
   ParsedFiniteElement<dim,dim> fe_builder;
 
-  ParsedFunction<dim, dim+1>        exact_solution;
-  ParsedFunction<dim, dim+1>        forcing_term;
+  ParsedFunction<dim>        exact_solution;
+  ParsedFunction<dim>        forcing_term;
 
-  ParsedFunction<dim, dim+1>        initial_solution;
-  ParsedFunction<dim, dim+1>        initial_solution_dot;
-  ParsedDirichletBCs<dim,dim,dim+1> dirichlet_bcs;
-  ParsedDirichletBCs<dim,dim,dim+1> dirichlet_dot;
+  ParsedFunction<dim>        initial_solution;
+  ParsedFunction<dim>        initial_solution_dot;
+  ParsedDirichletBCs<dim> dirichlet_bcs;
+  ParsedDirichletBCs<dim> dirichlet_dot;
 
   ParsedDataOut<dim, dim>                  data_out;
 

--- a/examples/dynamic_stokes/source/stokes_ida.cc
+++ b/examples/dynamic_stokes/source/stokes_ida.cc
@@ -615,7 +615,7 @@ void Stokes<dim>::output_step(const double t,
     }
   data_out.add_data_vector (distributed_solution_dot, print(sol_dot_names,","));
 
-  data_out.write_data_and_clear("",*mapping);
+  data_out.write_data_and_clear(*mapping);
 
   computing_timer.exit_section ();
 }

--- a/examples/dynamic_stokes/source/stokes_ida.cc
+++ b/examples/dynamic_stokes/source/stokes_ida.cc
@@ -69,12 +69,12 @@ Stokes<dim>::Stokes (const MPI_Comm &communicator)
              "FESystem[FE_Q(2)^dim-FE_Q(1)]",
              "u,u,p"),
 
-  exact_solution("Exact solution"),
-  forcing_term("Forcing term"),
-  initial_solution("Initial solution"),
-  initial_solution_dot("Initial solution_dot"),
-  dirichlet_bcs("Dirichlet BCs", "u,u,p", "0=u"),
-  dirichlet_dot("Dirichlet dot", "u,u,p", "0=u"),
+  exact_solution("Exact solution", 3),
+  forcing_term("Forcing term", 3),
+  initial_solution("Initial solution", 3),
+  initial_solution_dot("Initial solution_dot", 3),
+  dirichlet_bcs("Dirichlet BCs", 3, "u,u,p", "0=u"),
+  dirichlet_dot("Dirichlet dot", 3, "u,u,p", "0=u"),
 
   data_out("Output Parameters", "vtu"),
   dae(*this)

--- a/examples/heat_equation/source/heat_ida.cc
+++ b/examples/heat_equation/source/heat_ida.cc
@@ -456,7 +456,7 @@ void Heat<dim>::output_step(const double t,
     }
   data_out.add_data_vector (distributed_solution_dot, print(sol_dot_names,","));
 
-  data_out.write_data_and_clear("",*mapping);
+  data_out.write_data_and_clear(*mapping);
   eh.error_from_exact(*mapping, *dof_handler, distributed_solution, exact_solution);
 
   computing_timer.exit_section ();

--- a/examples/poisson/poisson.cc
+++ b/examples/poisson/poisson.cc
@@ -73,8 +73,8 @@ int main(int argc, char **argv)
   ParsedGridGenerator<dim,spacedim> pgg;
 
   ParsedFiniteElement<dim,spacedim> pfe;
-  ParsedDirichletBCs<dim,dim,1> bcs;
-  ParsedFunction<spacedim> kappa("Kappa", "1.0");
+  ParsedDirichletBCs<dim> bcs;
+  ParsedFunction<spacedim> kappa("Kappa", 1, "1.0");
   ParsedFunction<spacedim> force("Forcing term");
   ParsedFunction<spacedim> exact("Exact solution");
 

--- a/include/deal2lkit/parsed_dirichlet_bcs.h
+++ b/include/deal2lkit/parsed_dirichlet_bcs.h
@@ -51,8 +51,9 @@ D2K_NAMESPACE_OPEN
  *
  * // create parsed_dirichlet object
  *
- * ParsedDirichletBCs<dim,spacedim,n_components>
+ * ParsedDirichletBCs<dim,spacedim>
  *    parsed_dirichlet("Dirichlet BCs", // name for the section of the Parameter Handler to use
+ *                     n_components,    // number of components of the problem
  *                     "u,u,p",         // names of known components that can be used instead of component numbers
  *                     "0=u % 1=2 % 3=u.N % 6=ALL", // boundary_id = component;other_component % other_id = comp; other_comp
  *                     "0=x;y;0 % 1=0;0;0 % 3=x;2;0 % 6=y*k;0;k", // boundary_id = expression % other_id = other_expression
@@ -87,8 +88,8 @@ D2K_NAMESPACE_OPEN
  * @endcode
  */
 
-template <int dim, int spacedim, int n_components>
-class ParsedDirichletBCs : public ParsedMappedFunctions<spacedim,n_components>
+template <int dim, int spacedim=dim>
+class ParsedDirichletBCs : public ParsedMappedFunctions<spacedim>
 {
 public:
   /**
@@ -109,6 +110,7 @@ public:
    *
    */
   ParsedDirichletBCs (const std::string &name = "Dirichlet BCs",
+                      const unsigned int &n_components=1,
                       const std::string &component_names = "",
                       const std::string &default_id_components = "0=ALL",
                       const std::string &default_id_functions = "",
@@ -262,324 +264,13 @@ public:
   void compute_nonzero_normal_flux_constraints (const DoFHandler<dim,spacedim> &dof_handler,
                                                 const Mapping< dim, spacedim > &mapping,
                                                 ConstraintMatrix &constraints) const;
+private:
+  /**
+   * Number of components of the underlying Function objects.
+   */
+  const unsigned int n_components;
 
 };
-
-
-template <int dim, int spacedim, int n_components>
-ParsedDirichletBCs<dim,spacedim,n_components>::
-ParsedDirichletBCs (const std::string &parsed_name,
-                    const std::string &parsed_component_names,
-                    const std::string &parsed_id_components,
-                    const std::string &parsed_id_functions,
-                    const std::string &parsed_constants)
-  :
-
-  ParsedMappedFunctions<spacedim,n_components>(parsed_name,
-                                               parsed_component_names,
-                                               parsed_id_components,
-                                               parsed_id_functions,
-                                               parsed_constants)
-{}
-
-template<int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::declare_parameters (ParameterHandler &prm)
-{
-  ParsedMappedFunctions<spacedim,n_components>::declare_parameters(prm);
-}
-
-template<int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::parse_parameters_call_back ()
-{
-  ParsedMappedFunctions<spacedim,n_components>::parse_parameters_call_back();
-}
-
-template<int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::interpolate_boundary_values(const DoFHandler<dim,spacedim> &dof_handler,
-    ConstraintMatrix &constraints) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    VectorTools::interpolate_boundary_values (dof_handler,
-                                              ids[i],
-                                              *(this->get_mapped_function(ids[i])),
-                                              constraints,
-                                              this->get_mapped_mask(ids[i]));
-}
-
-template<int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::interpolate_boundary_values(const Mapping<dim,spacedim> &mapping,
-    const DoFHandler<dim,spacedim> &dof_handler,
-    ConstraintMatrix &constraints) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    VectorTools::interpolate_boundary_values (mapping,
-                                              dof_handler,
-                                              ids[i],
-                                              *(this->get_mapped_function(ids[i])),
-                                              constraints,
-                                              this->get_mapped_mask(ids[i]));
-}
-
-template<int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::interpolate_boundary_values( const DoFHandler<dim,spacedim> &dof_handler,
-    std::map<types::global_dof_index,double> &d_dofs) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    VectorTools::interpolate_boundary_values (dof_handler,
-                                              ids[i],
-                                              *(this->get_mapped_function(ids[i])),
-                                              d_dofs,
-                                              this->get_mapped_mask(ids[i]));
-}
-
-template<int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::interpolate_boundary_values(const Mapping<dim,spacedim> &mapping,
-    const DoFHandler<dim,spacedim> &dof_handler,
-    std::map<types::global_dof_index,double> &d_dofs) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    VectorTools::interpolate_boundary_values (mapping,
-                                              dof_handler,
-                                              ids[i],
-                                              *(this->get_mapped_function(ids[i])),
-                                              d_dofs,
-                                              this->get_mapped_mask(ids[i]));
-}
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::project_boundary_values (const Mapping<dim,spacedim> &mapping,
-    const DoFHandler<dim,spacedim> &dof_handler,
-    const Quadrature<dim-1> &quadrature,
-    ConstraintMatrix &constraints) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    {
-      typename FunctionMap<spacedim>::type boundary_map;
-
-      Function<spacedim> *f;
-      f = &(*(this->get_mapped_function(ids[i])));
-      boundary_map[ids[i]] = f;
-
-      // from bool to int
-      std::vector<unsigned int> component_mapping;
-      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
-        for (unsigned int j=0; j<component_mapping.size(); ++j)
-          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
-
-      VectorTools::project_boundary_values(mapping,
-                                           dof_handler,
-                                           boundary_map,
-                                           quadrature,
-                                           constraints,
-                                           component_mapping);
-    }
-}
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::project_boundary_values (const DoFHandler<dim,spacedim> &dof_handler,
-    const Quadrature<dim-1> &quadrature,
-    ConstraintMatrix &constraints) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    {
-      typename FunctionMap<spacedim>::type boundary_map;
-
-      Function<spacedim> *f;
-      f = &(*(this->get_mapped_function(ids[i])));
-      boundary_map[ids[i]] = f;
-
-      // from bool to int
-      std::vector<unsigned int> component_mapping;
-      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
-        for (unsigned int j=0; j<component_mapping.size(); ++j)
-          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
-
-      VectorTools::project_boundary_values(dof_handler,
-                                           boundary_map,
-                                           quadrature,
-                                           constraints,
-                                           component_mapping);
-    }
-}
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::project_boundary_values (const Mapping<dim,spacedim> &mapping,
-    const DoFHandler<dim,spacedim> &dof_handler,
-    const Quadrature<dim-1> &quadrature,
-    std::map<types::global_dof_index,double> &projected_bv) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    {
-      typename FunctionMap<spacedim>::type boundary_map;
-
-      Function<spacedim> *f;
-      f = &(*(this->get_mapped_function(ids[i])));
-      boundary_map[ids[i]] = f;
-
-      // from bool to int
-      std::vector<unsigned int> component_mapping;
-      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
-        for (unsigned int j=0; j<n_components; ++j)
-          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
-
-      VectorTools::project_boundary_values(mapping,
-                                           dof_handler,
-                                           boundary_map,
-                                           quadrature,
-                                           projected_bv,
-                                           component_mapping);
-
-    }
-}
-
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::project_boundary_values (const DoFHandler<dim,spacedim> &dof_handler,
-    const Quadrature<dim-1> &quadrature,
-    std::map<types::global_dof_index,double> &projected_bv) const
-{
-  std::vector<unsigned int> ids = this->get_mapped_ids();
-  for (unsigned int i=0; i<ids.size(); ++i)
-    {
-      typename FunctionMap<spacedim>::type boundary_map;
-
-      Function<spacedim> *f;
-      f = &(*(this->get_mapped_function(ids[i])));
-      boundary_map[ids[i]] = f;
-
-      // from bool to int
-      std::vector<unsigned int> component_mapping;
-      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
-        for (unsigned int j=0; j<n_components; ++j)
-          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
-
-      VectorTools::project_boundary_values(dof_handler,
-                                           boundary_map,
-                                           quadrature,
-                                           projected_bv,
-                                           component_mapping);
-    }
-}
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::compute_no_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
-    ConstraintMatrix &constraints) const
-{
-  std::set<types::boundary_id> no_normal_flux_boundaries;
-
-  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
-
-  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
-    {
-      std::vector<unsigned int> normal_ids = (it->second).first;
-
-      for (unsigned int i=0; i<normal_ids.size(); ++i)
-        no_normal_flux_boundaries.insert(normal_ids[i]);
-
-      VectorTools::compute_no_normal_flux_constraints(dof_handler,
-                                                      (it->second).second, // unsigned int first component vector
-                                                      no_normal_flux_boundaries,
-                                                      constraints);
-    }
-}
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::compute_no_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
-    const Mapping< dim, spacedim > &mapping,
-    ConstraintMatrix &constraints) const
-{
-  std::set<types::boundary_id> no_normal_flux_boundaries;
-
-  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
-
-  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
-    {
-      std::vector<unsigned int> normal_ids = (it->second).first;
-
-      for (unsigned int i=0; i<normal_ids.size(); ++i)
-        no_normal_flux_boundaries.insert(normal_ids[i]);
-
-      VectorTools::compute_no_normal_flux_constraints(dof_handler,
-                                                      (it->second).second, // unsigned int first component vector
-                                                      no_normal_flux_boundaries,
-                                                      constraints,
-                                                      mapping);
-    }
-}
-
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::compute_nonzero_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
-    ConstraintMatrix &constraints) const
-{
-  std::set<types::boundary_id> no_normal_flux_boundaries;
-
-  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
-
-  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
-    {
-      typename FunctionMap<spacedim>::type boundary_map;
-
-      std::vector<unsigned int> normal_ids = (it->second).first;
-      unsigned int fcv = (it->second).second; // unsigned int first component vector
-
-      for (unsigned int i=0; i<normal_ids.size(); ++i)
-        {
-          Function<spacedim> *f;
-          f = &(*(this->get_mapped_normal_function(normal_ids[i], fcv)));
-          boundary_map[normal_ids[i]] = f;
-          no_normal_flux_boundaries.insert(normal_ids[i]);
-        }
-
-      VectorTools::compute_nonzero_normal_flux_constraints(dof_handler,
-                                                           fcv,
-                                                           no_normal_flux_boundaries,
-                                                           boundary_map,
-                                                           constraints);
-    }
-}
-
-template <int dim, int spacedim, int n_components>
-void ParsedDirichletBCs<dim,spacedim,n_components>::compute_nonzero_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
-    const Mapping< dim, spacedim > &mapping,
-    ConstraintMatrix &constraints) const
-{
-  std::set<types::boundary_id> no_normal_flux_boundaries;
-
-  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
-
-  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
-    {
-      typename FunctionMap<spacedim>::type boundary_map;
-
-      std::vector<unsigned int> normal_ids = (it->second).first;
-      unsigned int fcv = (it->second).second; // unsigned int first component vector
-
-      for (unsigned int i=0; i<normal_ids.size(); ++i)
-        {
-          Function<spacedim> *f;
-
-          f = &(*(this->get_mapped_normal_function(normal_ids[i], fcv)));
-          boundary_map[normal_ids[i]] = f;
-          no_normal_flux_boundaries.insert(normal_ids[i]);
-        }
-
-      VectorTools::compute_nonzero_normal_flux_constraints(dof_handler,
-                                                           fcv,
-                                                           no_normal_flux_boundaries,
-                                                           boundary_map,
-                                                           constraints,
-                                                           mapping);
-    }
-}
-
 
 D2K_NAMESPACE_CLOSE
 

--- a/include/deal2lkit/parsed_function.h
+++ b/include/deal2lkit/parsed_function.h
@@ -26,10 +26,10 @@ D2K_NAMESPACE_OPEN
 
 /**
  * A deal2lkit wrapper for dealii::Functions::ParsedFunction. The
- * template integers specify the dimension of points this function
- * accepts, and the number of components of the Function.
+ * template integer specify the dimension of points this function
+ * accepts.
  */
-template<int dim, int ncomponents=1>
+template<int dim>
 class ParsedFunction : public ParameterAcceptor, public Functions::ParsedFunction<dim>
 {
 public:
@@ -37,8 +37,17 @@ public:
    * Constructor: takes an optional name for the section. If the
    * optional expression string is given, than it is used to set the
    * expression as soon as the parameters are declared.
+   *
+   * The n_components parameter is used to determine the number of
+   * components of this function. It defaults to one, and once it is
+   * set in the constructor, it cannot be changed by parameter file.
+   * The default_expression, instead, can be changed by acting on the
+   * parameter file. An exception will be thrown if the number of
+   * components of the expression does not coincide with the parameter
+   * passed at construction time to this function.
    */
   ParsedFunction(const std::string &name="",
+                 const unsigned int &n_components=1,
                  const std::string &default_exp="",
                  const std::string &default_const="");
 
@@ -59,40 +68,8 @@ private:
    */
   const std::string default_exp;
   const std::string default_const;
+  const unsigned int n_components;
 };
-
-// ============================================================
-// Explicit template functions
-// ============================================================
-
-template<int dim, int ncomponents>
-ParsedFunction<dim, ncomponents>::ParsedFunction(const std::string &name,
-                                                 const std::string &default_exp,
-                                                 const std::string &default_const) :
-  ParameterAcceptor(name),
-  Functions::ParsedFunction<dim>(ncomponents),
-  default_exp(default_exp),
-  default_const(default_const)
-{}
-
-
-template<int dim, int ncomponents>
-void ParsedFunction<dim, ncomponents>:: declare_parameters(ParameterHandler &prm)
-{
-  Functions::ParsedFunction<dim>::declare_parameters(prm, ncomponents);
-  if (default_exp != "")
-    prm.set("Function expression", default_exp);
-  if (default_const != "")
-    prm.set("Function constants", default_const);
-}
-
-
-template<int dim, int ncomponents>
-void ParsedFunction<dim, ncomponents>:: parse_parameters(ParameterHandler &prm)
-{
-  Functions::ParsedFunction<dim>::parse_parameters(prm);
-}
-
 
 D2K_NAMESPACE_CLOSE
 

--- a/include/deal2lkit/parsed_mapped_functions.h
+++ b/include/deal2lkit/parsed_mapped_functions.h
@@ -32,14 +32,12 @@ using namespace dealii;
 D2K_NAMESPACE_OPEN
 
 /**
- * ParsedMappedFunctions object.
- * It allows you to set a mapped functions, i.e., parsed functions
- * acting on specified id (boundary_id, material_id,etc..) and on
- * specified components.
+ * ParsedMappedFunctions object.  It allows you to set a mapped
+ * functions, i.e., parsed functions acting on specified id
+ * (boundary_id, material_id,etc..) and on specified components.
  *
  * Dirichlet Boundary conditions, Neumann boundary conditions
  * and forcing terms can be easily handled with this class.
- *
  *
  * A typical usage of this class is the following
  *
@@ -51,8 +49,9 @@ D2K_NAMESPACE_OPEN
  *
  * // create parsed_mapped_functions object
  *
- * ParsedMappedFunctions<spacedim,n_components>
+ * ParsedMappedFunctions<spacedim>
  *    parsed_mapped_functions("Forcing terms", // name for the section of the Parameter Handler to use
+ *                     n_components, // The number of components of the function
  *                     "u,u,p",         // names of known components that can be used instead of component numbers
  *                     "0=u % 1=2 % 6=ALL", // boundary_id = component;other_component % other_id = comp; other_comp
  *                     "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k", // boundary_id = expression % other_id = other_expression
@@ -68,7 +67,7 @@ D2K_NAMESPACE_OPEN
  * @endcode
  */
 
-template <int spacedim, int n_components>
+template <int spacedim>
 class ParsedMappedFunctions : public ParameterAcceptor
 {
 public:
@@ -78,7 +77,9 @@ public:
    * It takes:
    * - the name for the section of the Parameter Handler to use
    *
-   * - the names of known components that can be used instead of component numbers
+   * - the number of components that this function has
+   *
+   * - the default names of known components that can be used instead of component numbers
    *
    * - a list of ids and components where the boundary conditions must be applied, which is
    *   a string with the following pattern boundary_id = component;other_component % other_id = comp; other_comp
@@ -90,6 +91,7 @@ public:
    *
    */
   ParsedMappedFunctions  (const std::string &name = "Mapped Functions",
+                          const unsigned int &n_components=1,
                           const std::string &component_names = "",
                           const std::string &default_id_components = "0=ALL",
                           const std::string &default_id_functions = "",
@@ -201,6 +203,7 @@ protected:
   std::map<unsigned int, std::string> id_str_functions;
   std::map<std::pair<unsigned int, unsigned int>, shared_ptr<dealii::Functions::ParsedFunction<spacedim> > > _normal_functions;
 
+  const unsigned int n_components;
 };
 
 

--- a/source/parsed_dirichlet_bcs.cc
+++ b/source/parsed_dirichlet_bcs.cc
@@ -1,0 +1,595 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal2lkit authors
+//
+//    This file is part of the deal2lkit library.
+//
+//    The deal2lkit library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal2lkit distribution.
+//
+//-----------------------------------------------------------
+
+#include <deal2lkit/parsed_dirichlet_bcs.h>
+
+
+
+D2K_NAMESPACE_OPEN
+
+
+
+template <int dim, int spacedim>
+ParsedDirichletBCs<dim,spacedim>::
+ParsedDirichletBCs (const std::string &parsed_name,
+                    const unsigned int &n_components,
+                    const std::string &parsed_component_names,
+                    const std::string &parsed_id_components,
+                    const std::string &parsed_id_functions,
+                    const std::string &parsed_constants)
+  :
+
+  ParsedMappedFunctions<spacedim>(parsed_name,
+                                  n_components,
+                                  parsed_component_names,
+                                  parsed_id_components,
+                                  parsed_id_functions,
+                                  parsed_constants),
+  n_components(n_components)
+{}
+
+template<int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::declare_parameters (ParameterHandler &prm)
+{
+  ParsedMappedFunctions<spacedim>::declare_parameters(prm);
+}
+
+template<int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::parse_parameters_call_back ()
+{
+  ParsedMappedFunctions<spacedim>::parse_parameters_call_back();
+}
+
+template<int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::interpolate_boundary_values(const DoFHandler<dim,spacedim> &dof_handler,
+    ConstraintMatrix &constraints) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    VectorTools::interpolate_boundary_values (dof_handler,
+                                              ids[i],
+                                              *(this->get_mapped_function(ids[i])),
+                                              constraints,
+                                              this->get_mapped_mask(ids[i]));
+}
+
+template<int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::interpolate_boundary_values(const Mapping<dim,spacedim> &mapping,
+    const DoFHandler<dim,spacedim> &dof_handler,
+    ConstraintMatrix &constraints) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    VectorTools::interpolate_boundary_values (mapping,
+                                              dof_handler,
+                                              ids[i],
+                                              *(this->get_mapped_function(ids[i])),
+                                              constraints,
+                                              this->get_mapped_mask(ids[i]));
+}
+
+template<int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::interpolate_boundary_values( const DoFHandler<dim,spacedim> &dof_handler,
+    std::map<types::global_dof_index,double> &d_dofs) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    VectorTools::interpolate_boundary_values (dof_handler,
+                                              ids[i],
+                                              *(this->get_mapped_function(ids[i])),
+                                              d_dofs,
+                                              this->get_mapped_mask(ids[i]));
+}
+
+template<int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::interpolate_boundary_values(const Mapping<dim,spacedim> &mapping,
+    const DoFHandler<dim,spacedim> &dof_handler,
+    std::map<types::global_dof_index,double> &d_dofs) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    VectorTools::interpolate_boundary_values (mapping,
+                                              dof_handler,
+                                              ids[i],
+                                              *(this->get_mapped_function(ids[i])),
+                                              d_dofs,
+                                              this->get_mapped_mask(ids[i]));
+}
+
+
+// [TODO] Fix this in deal.II.
+
+template<>
+void ParsedDirichletBCs<1, 2>::project_boundary_values(dealii::DoFHandler<1, 2> const &, dealii::Quadrature<0> const &, dealii::ConstraintMatrix &) const
+{
+  ExcImpossibleInDim(1);
+}
+
+template<>
+void ParsedDirichletBCs<1, 3>::project_boundary_values(dealii::DoFHandler<1, 3> const &, dealii::Quadrature<0> const &, dealii::ConstraintMatrix &) const
+{
+  ExcImpossibleInDim(1);
+}
+
+template<>
+void ParsedDirichletBCs<2, 3>::project_boundary_values(dealii::DoFHandler<2, 3> const &, dealii::Quadrature<1> const &, dealii::ConstraintMatrix &) const
+{
+  ExcNotImplemented();
+}
+
+
+template<>
+void ParsedDirichletBCs<1, 2>::project_boundary_values(const Mapping<1,2> &,
+                                                       dealii::DoFHandler<1, 2> const &,
+                                                       dealii::Quadrature<0> const &, dealii::ConstraintMatrix &) const
+{
+  ExcImpossibleInDim(1);
+}
+
+template<>
+void ParsedDirichletBCs<1, 3>::project_boundary_values(const Mapping<1,3> &,
+                                                       dealii::DoFHandler<1, 3> const &,
+                                                       dealii::Quadrature<0> const &, dealii::ConstraintMatrix &) const
+{
+  ExcImpossibleInDim(1);
+}
+
+
+
+template<>
+void ParsedDirichletBCs<2, 3>::project_boundary_values(const Mapping<2,3> &,
+                                                       dealii::DoFHandler<2, 3> const &,
+                                                       dealii::Quadrature<1> const &, dealii::ConstraintMatrix &) const
+{
+  ExcNotImplemented();
+}
+
+
+
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::project_boundary_values (const Mapping<dim,spacedim> &mapping,
+    const DoFHandler<dim,spacedim> &dof_handler,
+    const Quadrature<dim-1> &quadrature,
+    ConstraintMatrix &constraints) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    {
+      typename FunctionMap<spacedim>::type boundary_map;
+
+      Function<spacedim> *f;
+      f = &(*(this->get_mapped_function(ids[i])));
+      boundary_map[ids[i]] = f;
+
+      // from bool to int
+      std::vector<unsigned int> component_mapping;
+      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
+        for (unsigned int j=0; j<component_mapping.size(); ++j)
+          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
+
+      VectorTools::project_boundary_values(mapping,
+                                           dof_handler,
+                                           boundary_map,
+                                           quadrature,
+                                           constraints,
+                                           component_mapping);
+    }
+}
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::project_boundary_values (const DoFHandler<dim,spacedim> &dof_handler,
+    const Quadrature<dim-1> &quadrature,
+    ConstraintMatrix &constraints) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    {
+      typename FunctionMap<spacedim>::type boundary_map;
+
+      Function<spacedim> *f;
+      f = &(*(this->get_mapped_function(ids[i])));
+      boundary_map[ids[i]] = f;
+
+      // from bool to int
+      std::vector<unsigned int> component_mapping;
+      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
+        for (unsigned int j=0; j<component_mapping.size(); ++j)
+          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
+
+      VectorTools::project_boundary_values(dof_handler,
+                                           boundary_map,
+                                           quadrature,
+                                           constraints,
+                                           component_mapping);
+    }
+}
+
+template<>
+void
+ParsedDirichletBCs<1,2>::project_boundary_values(Mapping<1, 2> const &,
+                                                 DoFHandler<1, 2> const &,
+                                                 Quadrature<0> const &,
+                                                 std::map<unsigned int, double> &) const
+{
+  Assert(false, ExcImpossibleInDim(1));
+}
+
+template<>
+void
+ParsedDirichletBCs<1,3>::project_boundary_values(Mapping<1, 3> const &,
+                                                 DoFHandler<1, 3> const &,
+                                                 Quadrature<0> const &,
+                                                 std::map<unsigned int, double> &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+
+template<>
+void
+ParsedDirichletBCs<2,3>::project_boundary_values(Mapping<2, 3> const &,
+                                                 DoFHandler<2, 3> const &,
+                                                 Quadrature<1> const &,
+                                                 std::map<unsigned int, double> &) const
+{
+  Assert(false,ExcImpossibleInDim(2));
+}
+
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::project_boundary_values (const Mapping<dim,spacedim> &mapping,
+    const DoFHandler<dim,spacedim> &dof_handler,
+    const Quadrature<dim-1> &quadrature,
+    std::map<types::global_dof_index,double> &projected_bv) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    {
+      typename FunctionMap<spacedim>::type boundary_map;
+
+      Function<spacedim> *f;
+      f = &(*(this->get_mapped_function(ids[i])));
+      boundary_map[ids[i]] = f;
+
+      // from bool to int
+      std::vector<unsigned int> component_mapping;
+      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
+        for (unsigned int j=0; j<n_components; ++j)
+          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
+
+      VectorTools::project_boundary_values(mapping,
+                                           dof_handler,
+                                           boundary_map,
+                                           quadrature,
+                                           projected_bv,
+                                           component_mapping);
+
+    }
+}
+
+
+template <>
+void ParsedDirichletBCs<1,2>::project_boundary_values (const DoFHandler<1,2> &,
+                                                       const Quadrature<0> &,
+                                                       std::map<types::global_dof_index,double> &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+template <>
+void ParsedDirichletBCs<1,3>::project_boundary_values (const DoFHandler<1,3> &,
+                                                       const Quadrature<0> &,
+                                                       std::map<types::global_dof_index,double> &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+template <>
+void ParsedDirichletBCs<2,3>::project_boundary_values (const DoFHandler<2,3> &,
+                                                       const Quadrature<1> &,
+                                                       std::map<types::global_dof_index,double> &) const
+{
+  Assert(false,ExcNotImplemented());
+}
+
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::project_boundary_values (const DoFHandler<dim,spacedim> &dof_handler,
+    const Quadrature<dim-1> &quadrature,
+    std::map<types::global_dof_index,double> &projected_bv) const
+{
+  std::vector<unsigned int> ids = this->get_mapped_ids();
+  for (unsigned int i=0; i<ids.size(); ++i)
+    {
+      typename FunctionMap<spacedim>::type boundary_map;
+
+      Function<spacedim> *f;
+      f = &(*(this->get_mapped_function(ids[i])));
+      boundary_map[ids[i]] = f;
+
+      // from bool to int
+      std::vector<unsigned int> component_mapping;
+      if (spacedim > 1) // component_mapping is not supported in deal.II for dim==1
+        for (unsigned int j=0; j<n_components; ++j)
+          component_mapping.push_back(this->get_mapped_mask(ids[i])[j]);
+
+      VectorTools::project_boundary_values(dof_handler,
+                                           boundary_map,
+                                           quadrature,
+                                           projected_bv,
+                                           component_mapping);
+    }
+}
+
+
+
+template <>
+void ParsedDirichletBCs<1,1>::compute_no_normal_flux_constraints(const DoFHandler<1,1> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+template<>
+void ParsedDirichletBCs<1, 1>::compute_no_normal_flux_constraints(const DoFHandler<1, 1> &,
+    const Mapping<1, 1> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+
+template<>
+void ParsedDirichletBCs<1,1>::compute_nonzero_normal_flux_constraints(dealii::DoFHandler<1,1> const &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+template <>
+void ParsedDirichletBCs<1,1>::compute_nonzero_normal_flux_constraints (const DoFHandler<1,1> &,
+    const Mapping<1,1> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+
+template <>
+void ParsedDirichletBCs<1,2>::compute_no_normal_flux_constraints(const DoFHandler<1,2> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+template<>
+void ParsedDirichletBCs<1,2>::compute_no_normal_flux_constraints(const DoFHandler<1,2> &,
+    const Mapping<1,2> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+
+template<>
+void ParsedDirichletBCs<1,2>::compute_nonzero_normal_flux_constraints(dealii::DoFHandler<1,2> const &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+template <>
+void ParsedDirichletBCs<1,2>::compute_nonzero_normal_flux_constraints (const DoFHandler<1,2> &,
+    const Mapping<1,2> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+template <>
+void ParsedDirichletBCs<1,3>::compute_no_normal_flux_constraints(const DoFHandler<1,3> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+template<>
+void ParsedDirichletBCs<1,3>::compute_no_normal_flux_constraints(const DoFHandler<1,3> &,
+    const Mapping<1,3> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+
+template<>
+void ParsedDirichletBCs<1,3>::compute_nonzero_normal_flux_constraints(dealii::DoFHandler<1,3> const &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+template <>
+void ParsedDirichletBCs<1,3>::compute_nonzero_normal_flux_constraints (const DoFHandler<1,3> &,
+    const Mapping<1,3> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+
+template <>
+void ParsedDirichletBCs<2,3>::compute_no_normal_flux_constraints(const DoFHandler<2,3> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(2));
+}
+
+template<>
+void ParsedDirichletBCs<2,3>::compute_no_normal_flux_constraints(const DoFHandler<2,3> &,
+    const Mapping<2,3> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(2));
+}
+
+
+
+template<>
+void ParsedDirichletBCs<2,3>::compute_nonzero_normal_flux_constraints(dealii::DoFHandler<2,3> const &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(2));
+}
+
+template <>
+void ParsedDirichletBCs<2,3>::compute_nonzero_normal_flux_constraints (const DoFHandler<2,3> &,
+    const Mapping<2,3> &,
+    ConstraintMatrix &) const
+{
+  Assert(false,ExcImpossibleInDim(1));
+}
+
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::compute_no_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
+    ConstraintMatrix &constraints) const
+{
+  std::set<types::boundary_id> no_normal_flux_boundaries;
+
+  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
+
+  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
+    {
+      std::vector<unsigned int> normal_ids = (it->second).first;
+
+      for (unsigned int i=0; i<normal_ids.size(); ++i)
+        no_normal_flux_boundaries.insert(normal_ids[i]);
+
+      VectorTools::compute_no_normal_flux_constraints(dof_handler,
+                                                      (it->second).second, // unsigned int first component vector
+                                                      no_normal_flux_boundaries,
+                                                      constraints);
+    }
+}
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::compute_no_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
+    const Mapping< dim, spacedim > &mapping,
+    ConstraintMatrix &constraints) const
+{
+  std::set<types::boundary_id> no_normal_flux_boundaries;
+
+  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
+
+  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
+    {
+      std::vector<unsigned int> normal_ids = (it->second).first;
+
+      for (unsigned int i=0; i<normal_ids.size(); ++i)
+        no_normal_flux_boundaries.insert(normal_ids[i]);
+
+      VectorTools::compute_no_normal_flux_constraints(dof_handler,
+                                                      (it->second).second, // unsigned int first component vector
+                                                      no_normal_flux_boundaries,
+                                                      constraints,
+                                                      mapping);
+    }
+}
+
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::compute_nonzero_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
+    ConstraintMatrix &constraints) const
+{
+  std::set<types::boundary_id> no_normal_flux_boundaries;
+
+  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
+
+  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
+    {
+      typename FunctionMap<spacedim>::type boundary_map;
+
+      std::vector<unsigned int> normal_ids = (it->second).first;
+      unsigned int fcv = (it->second).second; // unsigned int first component vector
+
+      for (unsigned int i=0; i<normal_ids.size(); ++i)
+        {
+          Function<spacedim> *f;
+          f = &(*(this->get_mapped_normal_function(normal_ids[i], fcv)));
+          boundary_map[normal_ids[i]] = f;
+          no_normal_flux_boundaries.insert(normal_ids[i]);
+        }
+
+      VectorTools::compute_nonzero_normal_flux_constraints(dof_handler,
+                                                           fcv,
+                                                           no_normal_flux_boundaries,
+                                                           boundary_map,
+                                                           constraints);
+    }
+}
+
+template <int dim, int spacedim>
+void ParsedDirichletBCs<dim,spacedim>::compute_nonzero_normal_flux_constraints(const DoFHandler<dim,spacedim> &dof_handler,
+    const Mapping< dim, spacedim > &mapping,
+    ConstraintMatrix &constraints) const
+{
+  std::set<types::boundary_id> no_normal_flux_boundaries;
+
+  typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::const_iterator it_type;
+
+  for (it_type it=this->mapped_normal_components.begin(); it != this->mapped_normal_components.end(); ++it)
+    {
+      typename FunctionMap<spacedim>::type boundary_map;
+
+      std::vector<unsigned int> normal_ids = (it->second).first;
+      unsigned int fcv = (it->second).second; // unsigned int first component vector
+
+      for (unsigned int i=0; i<normal_ids.size(); ++i)
+        {
+          Function<spacedim> *f;
+
+          f = &(*(this->get_mapped_normal_function(normal_ids[i], fcv)));
+          boundary_map[normal_ids[i]] = f;
+          no_normal_flux_boundaries.insert(normal_ids[i]);
+        }
+
+      VectorTools::compute_nonzero_normal_flux_constraints(dof_handler,
+                                                           fcv,
+                                                           no_normal_flux_boundaries,
+                                                           boundary_map,
+                                                           constraints,
+                                                           mapping);
+    }
+}
+
+template class ParsedDirichletBCs<1,1>;
+template class ParsedDirichletBCs<1,2>;
+template class ParsedDirichletBCs<1,3>;
+template class ParsedDirichletBCs<2,2>;
+template class ParsedDirichletBCs<2,3>;
+template class ParsedDirichletBCs<3,3>;
+
+D2K_NAMESPACE_CLOSE

--- a/source/parsed_function.cc
+++ b/source/parsed_function.cc
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal2lkit authors
+//
+//    This file is part of the deal2lkit library.
+//
+//    The deal2lkit library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal2lkit distribution.
+//
+//-----------------------------------------------------------
+
+#include <deal2lkit/parsed_function.h>
+#include <deal2lkit/utilities.h>
+
+
+D2K_NAMESPACE_OPEN
+
+template<int dim>
+ParsedFunction<dim>::ParsedFunction(const std::string &name,
+                                    const unsigned int &n_components,
+                                    const std::string &default_exp,
+                                    const std::string &default_const) :
+  ParameterAcceptor(name),
+  Functions::ParsedFunction<dim>(n_components),
+  default_exp(default_exp),
+  default_const(default_const),
+  n_components(n_components)
+{}
+
+
+template<int dim>
+void ParsedFunction<dim>::declare_parameters(ParameterHandler &prm)
+{
+  Functions::ParsedFunction<dim>::declare_parameters(prm, n_components);
+  if (default_exp != "")
+    prm.set("Function expression", default_exp);
+  if (default_const != "")
+    prm.set("Function constants", default_const);
+}
+
+
+template<int dim>
+void ParsedFunction<dim>::parse_parameters(ParameterHandler &prm)
+{
+  Functions::ParsedFunction<dim>::parse_parameters(prm);
+}
+
+
+template class ParsedFunction<1>;
+template class ParsedFunction<2>;
+template class ParsedFunction<3>;
+
+D2K_NAMESPACE_CLOSE

--- a/source/parsed_mapped_functions.cc
+++ b/source/parsed_mapped_functions.cc
@@ -18,22 +18,24 @@
 
 D2K_NAMESPACE_OPEN
 
-template <int spacedim, int n_components>
-ParsedMappedFunctions<spacedim,n_components>::ParsedMappedFunctions(const std::string &parsed_name,
-    const std::string &parsed_component_names,
-    const std::string &parsed_id_components,
-    const std::string &parsed_id_functions,
-    const std::string &parsed_constants):
+template <int spacedim>
+ParsedMappedFunctions<spacedim>::ParsedMappedFunctions(const std::string &parsed_name,
+                                                       const unsigned int &n_components,
+                                                       const std::string &parsed_component_names,
+                                                       const std::string &parsed_id_components,
+                                                       const std::string &parsed_id_functions,
+                                                       const std::string &parsed_constants):
   ParameterAcceptor(parsed_name),
   name (parsed_name),
   str_id_components (parsed_id_components),
   str_id_functions (parsed_id_functions),
   str_component_names (parsed_component_names),
-  str_constants (parsed_constants)
+  str_constants (parsed_constants),
+  n_components(n_components)
 {}
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::add_normal_components()
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::add_normal_components()
 {
   std::vector<std::string> var = unique(_component_names);
   for (unsigned int i=0; i<var.size(); ++i)
@@ -49,8 +51,8 @@ void ParsedMappedFunctions<spacedim,n_components>::add_normal_components()
     }
 }
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::parse_parameters_call_back()
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::parse_parameters_call_back()
 {
   add_normal_components();
   _all_components = _component_names;
@@ -76,8 +78,8 @@ void ParsedMappedFunctions<spacedim,n_components>::parse_parameters_call_back()
 
 }
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::split_id_components(const std::string &parsed_idcomponents)
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::split_id_components(const std::string &parsed_idcomponents)
 {
   std::vector<std::string> idcomponents;
 
@@ -140,9 +142,9 @@ void ParsedMappedFunctions<spacedim,n_components>::split_id_components(const std
     }
 }
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::split_id_functions(const std::string &parsed_idfunctions,
-    const std::string &constants)
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::split_id_functions(const std::string &parsed_idfunctions,
+                                                         const std::string &constants)
 {
   std::vector<unsigned int> id_defined_functions;
 
@@ -212,9 +214,9 @@ void ParsedMappedFunctions<spacedim,n_components>::split_id_functions(const std:
 
 }
 
-template <int spacedim, int n_components>
+template <int spacedim>
 shared_ptr<dealii::Functions::ParsedFunction<spacedim> >
-ParsedMappedFunctions<spacedim,n_components>::get_mapped_normal_function(const unsigned int &id, const unsigned int &fcv) const
+ParsedMappedFunctions<spacedim>::get_mapped_normal_function(const unsigned int &id, const unsigned int &fcv) const
 {
   std::pair<unsigned int, unsigned int> id_fcv (id,fcv);
   Assert( _normal_functions.find(id_fcv) != _normal_functions.end(),
@@ -223,36 +225,36 @@ ParsedMappedFunctions<spacedim,n_components>::get_mapped_normal_function(const u
   return _normal_functions.at(id_fcv);
 }
 
-template <int spacedim, int n_components>
-shared_ptr<dealii::Functions::ParsedFunction<spacedim> > ParsedMappedFunctions<spacedim,n_components>::get_mapped_function(const unsigned int &id) const
+template <int spacedim>
+shared_ptr<dealii::Functions::ParsedFunction<spacedim> > ParsedMappedFunctions<spacedim>::get_mapped_function(const unsigned int &id) const
 {
   Assert( mapped_functions.find(id) != mapped_functions.end(),
           ExcIdNotFound(id));
   return mapped_functions.at(id).second;
 }
 
-template <int spacedim, int n_components>
-ComponentMask ParsedMappedFunctions<spacedim,n_components>::get_mapped_mask(const unsigned int &id) const
+template <int spacedim>
+ComponentMask ParsedMappedFunctions<spacedim>::get_mapped_mask(const unsigned int &id) const
 {
   Assert( mapped_functions.find(id) != mapped_functions.end(),
           ExcIdNotFound(id));
   return mapped_functions.at(id).first;
 }
 
-template <int spacedim, int n_components>
-std::vector<unsigned int> ParsedMappedFunctions<spacedim,n_components>::get_mapped_ids() const
+template <int spacedim>
+std::vector<unsigned int> ParsedMappedFunctions<spacedim>::get_mapped_ids() const
 {
   return ids;
 }
 
-template <int spacedim, int n_components>
-std::vector<unsigned int> ParsedMappedFunctions<spacedim,n_components>::get_mapped_normal_ids() const
+template <int spacedim>
+std::vector<unsigned int> ParsedMappedFunctions<spacedim>::get_mapped_normal_ids() const
 {
   return normal_ids;
 }
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::declare_parameters(ParameterHandler &prm)
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::declare_parameters(ParameterHandler &prm)
 {
   if (str_component_names != "")
     add_parameter(prm, &_component_names, "Known component names", str_component_names,
@@ -300,22 +302,22 @@ void ParsedMappedFunctions<spacedim,n_components>::declare_parameters(ParameterH
 
 }
 
-template <int spacedim, int n_components>
-bool ParsedMappedFunctions<spacedim,n_components>::acts_on_id(unsigned int &id) const
+template <int spacedim>
+bool ParsedMappedFunctions<spacedim>::acts_on_id(unsigned int &id) const
 {
   return id_components.find(id) != id_components.end();
 }
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::set_time(const double &t)
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::set_time(const double &t)
 {
   typedef typename std::map<unsigned int, shared_ptr<dealii::Functions::ParsedFunction<spacedim> > >::iterator it_type;
   for (it_type it=id_functions.begin(); it != id_functions.end(); ++it)
     it->second->set_time(t);
 }
 
-template <int spacedim, int n_components>
-void ParsedMappedFunctions<spacedim,n_components>::set_normal_functions()
+template <int spacedim>
+void ParsedMappedFunctions<spacedim>::set_normal_functions()
 {
   typedef std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int > >::iterator it_type;
 
@@ -352,22 +354,6 @@ void ParsedMappedFunctions<spacedim,n_components>::set_normal_functions()
 
 D2K_NAMESPACE_CLOSE
 
-template class deal2lkit::ParsedMappedFunctions<1,1>;
-
-template class deal2lkit::ParsedMappedFunctions<2,1>;
-template class deal2lkit::ParsedMappedFunctions<2,2>;
-template class deal2lkit::ParsedMappedFunctions<2,3>;
-template class deal2lkit::ParsedMappedFunctions<2,4>;
-template class deal2lkit::ParsedMappedFunctions<2,5>;
-template class deal2lkit::ParsedMappedFunctions<2,6>;
-template class deal2lkit::ParsedMappedFunctions<2,7>;
-template class deal2lkit::ParsedMappedFunctions<2,8>;
-
-template class deal2lkit::ParsedMappedFunctions<3,1>;
-template class deal2lkit::ParsedMappedFunctions<3,2>;
-template class deal2lkit::ParsedMappedFunctions<3,3>;
-template class deal2lkit::ParsedMappedFunctions<3,4>;
-template class deal2lkit::ParsedMappedFunctions<3,5>;
-template class deal2lkit::ParsedMappedFunctions<3,6>;
-template class deal2lkit::ParsedMappedFunctions<3,7>;
-template class deal2lkit::ParsedMappedFunctions<3,8>;
+template class deal2lkit::ParsedMappedFunctions<1>;
+template class deal2lkit::ParsedMappedFunctions<2>;
+template class deal2lkit::ParsedMappedFunctions<3>;

--- a/tests/parsed_dirichlet_bcs_01.cc
+++ b/tests/parsed_dirichlet_bcs_01.cc
@@ -27,7 +27,7 @@ int main ()
 {
   initlog();
 
-  ParsedDirichletBCs<2,2,1> pf("Dirichlet","u","0=ALL","0=0");
+  ParsedDirichletBCs<2,2> pf("Dirichlet",1,"u","0=ALL","0=0");
 
   ParameterAcceptor::initialize();
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_dirichlet_bcs_02.cc
+++ b/tests/parsed_dirichlet_bcs_02.cc
@@ -118,7 +118,7 @@ void FindBug<dim>::dirichlet_conditions ()
   for (unsigned int i=0; i<dof_handler.n_dofs(); ++i)
     dirichlet_dofs[i] = 1.;
 
-  ParsedDirichletBCs<dim,dim,dim+1> parsed_dirichlet("ParsedDirichletBCs","",(dim==2 ?"0=2" :"0=3"),(dim==2 ?"0=13;13;13" : "0=13;13;13;13"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",dim+1,"",(dim==2 ?"0=2" :"0=3"),(dim==2 ?"0=13;13;13" : "0=13;13;13;13"));
 //  if (dim ==2)
 //    ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_dirichlet_bcs_02_2D.prm", "used_parameters.prm");
 //  else

--- a/tests/parsed_dirichlet_bcs_03.cc
+++ b/tests/parsed_dirichlet_bcs_03.cc
@@ -59,9 +59,9 @@ void test ()
   triangulation.refine_global (1);
 
   dof_handler.distribute_dofs (fe);
-  ParsedDirichletBCs<dim,dim,1> parsed_dirichlet("Parsed Dirichlet BCs","","10=0 % 20=0",
-                                                 (dim==1 ?"10=x^2 % 20=x^2" :
-                                                  (dim==2 ?"10=x^2+y^2 % 20=x^2+y^2" :"10=x^2+y^2+z^2 % 20=x^2+y^2+z^2")));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("Parsed Dirichlet BCs",1,"","10=0 % 20=0",
+                                               (dim==1 ?"10=x^2 % 20=x^2" :
+                                                (dim==2 ?"10=x^2+y^2 % 20=x^2+y^2" :"10=x^2+y^2+z^2 % 20=x^2+y^2+z^2")));
 
   ParameterAcceptor::initialize();
   std::map<types::global_dof_index,double> boundary_values;

--- a/tests/parsed_dirichlet_bcs_04.cc
+++ b/tests/parsed_dirichlet_bcs_04.cc
@@ -71,9 +71,9 @@ void test ()
   boundary_map[20] = &f;
 
 
-  ParsedDirichletBCs<dim,dim,1> parsed_dirichlet("Parsed Dirichlet BCs","","10=0 % 20=0",
-                                                 (dim==1 ?"10=x^2 % 20=x^2" :
-                                                  (dim==2 ?"10=x^2+y^2 % 20=x^2+y^2" :"10=x^2+y^2+z^2 % 20=x^2+y^2+z^2")));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("Parsed Dirichlet BCs",1,"","10=0 % 20=0",
+                                               (dim==1 ?"10=x^2 % 20=x^2" :
+                                                (dim==2 ?"10=x^2+y^2 % 20=x^2+y^2" :"10=x^2+y^2+z^2 % 20=x^2+y^2+z^2")));
 
   ParameterAcceptor::initialize();
   std::map<types::global_dof_index,double> boundary_values;

--- a/tests/parsed_dirichlet_bcs_05.cc
+++ b/tests/parsed_dirichlet_bcs_05.cc
@@ -58,9 +58,10 @@ void test (const Triangulation<dim> &tr,
   //   boundary_ids.insert (j);
 
   // VectorTools::compute_no_normal_flux_constraints (dof, 0, boundary_ids, cm);
-  ParsedDirichletBCs<dim,dim,dim> parsed_dirichlet("ParsedDirichletBCs",
-                                                   (dim==2?"u,u":"u,u,u"),
-                                                   (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim,
+                                               (dim==2?"u,u":"u,u,u"),
+                                               (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"));
 
 
   ParameterAcceptor::initialize();

--- a/tests/parsed_dirichlet_bcs_06.cc
+++ b/tests/parsed_dirichlet_bcs_06.cc
@@ -57,9 +57,10 @@ void test (const Triangulation<dim> &tr,
 //     boundary_ids.insert (j);
 //
 //   VectorTools::compute_no_normal_flux_constraints (dof, 1, boundary_ids, cm);
-  ParsedDirichletBCs<dim,dim,dim+1> parsed_dirichlet("ParsedDirichletBCs",
-                                                     (dim==2?"p,u,u":"p,u,u,u"),
-                                                     (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim+1,
+                                               (dim==2?"p,u,u":"p,u,u,u"),
+                                               (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"));
 
 
   ParameterAcceptor::initialize();

--- a/tests/parsed_dirichlet_bcs_07.cc
+++ b/tests/parsed_dirichlet_bcs_07.cc
@@ -65,10 +65,11 @@ void test (const Triangulation<dim> &tr,
 
   //VectorTools::compute_nonzero_normal_flux_constraints (dof, 0, boundary_ids, function_map,  cm);
 
-  ParsedDirichletBCs<dim,dim,dim> parsed_dirichlet("ParsedDirichletBCs",
-                                                   (dim==2?"u,u":"u,u,u"),
-                                                   (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"),
-                                                   (dim==2?"0=1;1 % 1=1;1 % 2=1;1 % 3=1;1" :"0=1;1;1 % 1=1;1;1 % 2=1;1;1 % 3=1;1;1 % 4=1;1;1 % 5=1;1;1"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim,
+                                               (dim==2?"u,u":"u,u,u"),
+                                               (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"),
+                                               (dim==2?"0=1;1 % 1=1;1 % 2=1;1 % 3=1;1" :"0=1;1;1 % 1=1;1;1 % 2=1;1;1 % 3=1;1;1 % 4=1;1;1 % 5=1;1;1"));
 
   ParameterAcceptor::initialize();
   parsed_dirichlet.compute_nonzero_normal_flux_constraints(dof,cm);

--- a/tests/parsed_dirichlet_bcs_08.cc
+++ b/tests/parsed_dirichlet_bcs_08.cc
@@ -55,10 +55,11 @@ void test (const Triangulation<dim> &tr,
   ConstraintMatrix cm;
 
 
-  ParsedDirichletBCs<dim,dim,dim> parsed_dirichlet("ParsedDirichletBCs",
-                                                   (dim==2?"u,u":"u,u,u"),
-                                                   (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"),
-                                                   (dim==2?"0=0;0 % 1=0;0 % 2=0;0 % 3=0;0" :"0=0;0;0 % 1=0;0;0 % 2=0;0;0 % 3=0;0;0 % 4=0;0;0 % 5=0;0;0"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim,
+                                               (dim==2?"u,u":"u,u,u"),
+                                               (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"),
+                                               (dim==2?"0=0;0 % 1=0;0 % 2=0;0 % 3=0;0" :"0=0;0;0 % 1=0;0;0 % 2=0;0;0 % 3=0;0;0 % 4=0;0;0 % 5=0;0;0"));
 
   ParameterAcceptor::initialize();
   parsed_dirichlet.compute_nonzero_normal_flux_constraints(dof,cm);

--- a/tests/parsed_dirichlet_bcs_09.cc
+++ b/tests/parsed_dirichlet_bcs_09.cc
@@ -58,10 +58,11 @@ void test (const Triangulation<dim> &tr,
 //     boundary_ids.insert (j);
 //
 //   VectorTools::compute_no_normal_flux_constraints (dof, 1, boundary_ids, cm);
-  ParsedDirichletBCs<dim,dim,dim+1> parsed_dirichlet("ParsedDirichletBCs",
-                                                     (dim==2?"u,u,p":"u,u,u,p"),
-                                                     (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"),
-                                                     (dim==2?"0=0;0;0 % 1=1;1;0 % 2=2;2;0 % 3=3;3;0" :"0=0;0;0;0 % 1=1;1;1;0 % 2=2;2;2;0 % 3=3;3;3;0 % 4=4;4;4;0 % 5=5;5;5;0"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim+1,
+                                               (dim==2?"u,u,p":"u,u,u,p"),
+                                               (dim==2?"0=u.N % 1=u.N % 2=u.N % 3=u.N" :"0=u.N % 1=u.N % 2=u.N % 3=u.N % 4=u.N % 5=u.N"),
+                                               (dim==2?"0=0;0;0 % 1=1;1;0 % 2=2;2;0 % 3=3;3;0" :"0=0;0;0;0 % 1=1;1;1;0 % 2=2;2;2;0 % 3=3;3;3;0 % 4=4;4;4;0 % 5=5;5;5;0"));
 
 
   ParameterAcceptor::initialize();

--- a/tests/parsed_dirichlet_bcs_10.cc
+++ b/tests/parsed_dirichlet_bcs_10.cc
@@ -53,10 +53,11 @@ void test (const Triangulation<dim> &tr,
           << std::endl;
 
   ConstraintMatrix cm;
-  ParsedDirichletBCs<dim,dim,dim+dim> parsed_dirichlet("ParsedDirichletBCs",
-                                                       (dim==2?"u,u,v,v":"u,u,u,v,v,v"),
-                                                       (dim==2?"0=u.N;v.N" :"5=u.N;v.N"),
-                                                       (dim==2?"0=0;0;10;10" :"5=5;5;5;15;15;15"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim+dim,
+                                               (dim==2?"u,u,v,v":"u,u,u,v,v,v"),
+                                               (dim==2?"0=u.N;v.N" :"5=u.N;v.N"),
+                                               (dim==2?"0=0;0;10;10" :"5=5;5;5;15;15;15"));
 
 
   ParameterAcceptor::initialize();

--- a/tests/parsed_dirichlet_bcs_11.cc
+++ b/tests/parsed_dirichlet_bcs_11.cc
@@ -51,10 +51,11 @@ void test (const Triangulation<dim> &tr,
           << std::endl;
 
   ConstraintMatrix cm;
-  ParsedDirichletBCs<dim,dim,dim+1> parsed_dirichlet("ParsedDirichletBCs",
-                                                     (dim==2?"u,u,p":"u,u,u,p"),
-                                                     (dim==2?"0=u.N;p":"5=u.N;p"),
-                                                     (dim==2?"0=0;0;10" :"5=5;5;5;15"));
+  ParsedDirichletBCs<dim,dim> parsed_dirichlet("ParsedDirichletBCs",
+                                               dim+1,
+                                               (dim==2?"u,u,p":"u,u,u,p"),
+                                               (dim==2?"0=u.N;p":"5=u.N;p"),
+                                               (dim==2?"0=0;0;10" :"5=5;5;5;15"));
 
 
   ParameterAcceptor::initialize();

--- a/tests/parsed_function_01.output
+++ b/tests/parsed_function_01.output
@@ -1,4 +1,4 @@
 
-DEAL:parameters:deal2lkit::ParsedFunction<2, 1>::Function constants: 
-DEAL:parameters:deal2lkit::ParsedFunction<2, 1>::Function expression: 0
-DEAL:parameters:deal2lkit::ParsedFunction<2, 1>::Variable names: x,y,t
+DEAL:parameters:deal2lkit::ParsedFunction<2>::Function constants: 
+DEAL:parameters:deal2lkit::ParsedFunction<2>::Function expression: 0
+DEAL:parameters:deal2lkit::ParsedFunction<2>::Variable names: x,y,t

--- a/tests/parsed_function_03.cc
+++ b/tests/parsed_function_03.cc
@@ -24,7 +24,7 @@ int main ()
 {
   initlog();
 
-  ParsedFunction<2> pf("Function", "x^2+y^2");
+  ParsedFunction<2> pf("Function", 1, "x^2+y^2");
 
   ParameterAcceptor::initialize();
 

--- a/tests/parsed_function_04.cc
+++ b/tests/parsed_function_04.cc
@@ -23,7 +23,7 @@ int main ()
 {
   initlog();
 
-  ParsedFunction<2> pf("Function", "x^2+y^2+k", "k=1");
+  ParsedFunction<2> pf("Function", 1, "x^2+y^2+k", "k=1");
 
   ParameterAcceptor::initialize();
 

--- a/tests/parsed_mapped_functions_01.cc
+++ b/tests/parsed_mapped_functions_01.cc
@@ -28,7 +28,7 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p", "0=0;1 % 1=2 % 6=0;1;2","0=x;y;0 % 1=0;0;0 % 6=y*k;beta*y;k","k=1,beta=2");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p", "0=0;1 % 1=2 % 6=0;1;2","0=x;y;0 % 1=0;0;0 % 6=y*k;beta*y;k","k=1,beta=2");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_01.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_02.cc
+++ b/tests/parsed_mapped_functions_02.cc
@@ -29,9 +29,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u % 1=1 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u % 1=1 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_02.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_03.cc
+++ b/tests/parsed_mapped_functions_03.cc
@@ -28,9 +28,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=z % 1=1 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=z % 1=1 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_03.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_04.cc
+++ b/tests/parsed_mapped_functions_04.cc
@@ -28,9 +28,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u % 1=5 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u % 1=5 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_04.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_05.cc
+++ b/tests/parsed_mapped_functions_05.cc
@@ -29,9 +29,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u % 4=1 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u % 4=1 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_05.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_06.cc
+++ b/tests/parsed_mapped_functions_06.cc
@@ -28,9 +28,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u % 1=1 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u % 1=1 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_06.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_07.cc
+++ b/tests/parsed_mapped_functions_07.cc
@@ -28,11 +28,11 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions",
-                                 "u,u,p",
-                                 "0=0;1 % 1=2 % 6=ALL",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;beta*y;k",
-                                 "k=1,beta=2");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3,
+                               "u,u,p",
+                               "0=0;1 % 1=2 % 6=ALL",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;beta*y;k",
+                               "k=1,beta=2");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_07.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_08.cc
+++ b/tests/parsed_mapped_functions_08.cc
@@ -28,7 +28,7 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<3,4> pmf("Mapped functions");
+  ParsedMappedFunctions<3> pmf("Mapped functions", 4);
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_08.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_09.cc
+++ b/tests/parsed_mapped_functions_09.cc
@@ -31,7 +31,7 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<3,4> pmf("Mapped functions","","0=0;1 % 5=ALL % 3=ALL");
+  ParsedMappedFunctions<3> pmf("Mapped functions",4,"","0=0;1 % 5=ALL % 3=ALL");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_09.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_10.cc
+++ b/tests/parsed_mapped_functions_10.cc
@@ -31,7 +31,7 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<3,1> pmf("Mapped functions","","5=ALL % 3=ALL");
+  ParsedMappedFunctions<3> pmf("Mapped functions",1,"","5=ALL % 3=ALL");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_10.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_11.cc
+++ b/tests/parsed_mapped_functions_11.cc
@@ -28,9 +28,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u % 1=1 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u % 1=1 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize();
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_12.cc
+++ b/tests/parsed_mapped_functions_12.cc
@@ -29,9 +29,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u % 1=1 % 6=u;p",
-                                 "0=t;y;0 % 1=t;0;0 % 6=t;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u % 1=1 % 6=u;p",
+                               "0=t;y;0 % 1=t;0;0 % 6=t;0;k","k=1");
 
   ParameterAcceptor::initialize();
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_13.cc
+++ b/tests/parsed_mapped_functions_13.cc
@@ -28,9 +28,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p,j",
-                                 "0=u % 1=1 % 6=u;p",
-                                 "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p,j",
+                               "0=u % 1=1 % 6=u;p",
+                               "0=x;y;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_13.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/parsed_mapped_functions_14.cc
+++ b/tests/parsed_mapped_functions_14.cc
@@ -29,9 +29,9 @@ using namespace deal2lkit;
 int main ()
 {
   initlog();
-  ParsedMappedFunctions<2,3> pmf("Mapped Functions", "u,u,p",
-                                 "0=u.N % 1=1 % 6=u;p",
-                                 "0=0;0;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
+  ParsedMappedFunctions<2> pmf("Mapped Functions", 3, "u,u,p",
+                               "0=u.N % 1=1 % 6=u;p",
+                               "0=0;0;0 % 1=0;0;0 % 6=y*k;0;k","k=1");
 
   ParameterAcceptor::initialize(SOURCE_DIR "/parameters/parsed_mapped_functions_14.prm", "used_parameters.prm");
   ParameterAcceptor::prm.log_parameters(deallog);


### PR DESCRIPTION
This passage is useful for the pi-domus revolution. It is an incompatible change, which would free us from the necessity to have a component in the Interface.
