### PR TITLE
fix warning: 'get_tria' is deprecated

### DIFF
--- a/include/deal2lkit/error_handler.h
+++ b/include/deal2lkit/error_handler.h
@@ -318,7 +318,7 @@ void ErrorHandler<ntables>::error_from_exact(const Mapping<DH::dimension, DH::sp
                   ExcDimensionMismatch(exact.n_components, types[table_no].size()));
 
       std::vector< std::vector<double> > error( exact.n_components, std::vector<double>(4));
-      const unsigned int n_active_cells = dh.get_tria().n_global_active_cells();
+      const unsigned int n_active_cells = dh.get_triangulation().n_global_active_cells();
       const unsigned int n_dofs=dh.n_dofs();
 
       if (extras[table_no]["cells"])
@@ -355,7 +355,7 @@ void ErrorHandler<ntables>::error_from_exact(const Mapping<DH::dimension, DH::sp
           // Select one Component
           ComponentSelectFunction<spacedim> select_component ( component, 1. , exact.n_components);
 
-          Vector<float> difference_per_cell (dh.get_tria().n_global_active_cells());
+          Vector<float> difference_per_cell (dh.get_triangulation().n_global_active_cells());
 
           QGauss<dim> q_gauss((dh.get_fe().degree+1) * 2);
 
@@ -536,7 +536,7 @@ void ErrorHandler<ntables>::custom_error(const std::function<double(const unsign
 
       const unsigned int n_components = types.size();
       std::vector<double> c_error( types[table_no].size() );
-      const unsigned int n_active_cells = dh.get_tria().n_global_active_cells();
+      const unsigned int n_active_cells = dh.get_triangulation().n_global_active_cells();
       const unsigned int n_dofs=dh.n_dofs();
       if (add_table_extras)
         {

--- a/source/parsed_data_out.cc
+++ b/source/parsed_data_out.cc
@@ -145,7 +145,7 @@ void ParsedDataOut<dim,spacedim>::prepare_data_output(const DoFHandler<dim,space
           if (output_partitioning)
             {
               deallog << "Writing partitioning" << std::endl;
-              Vector<float> partitioning(dh.get_tria().n_active_cells());
+              Vector<float> partitioning(dh.get_triangulation().n_active_cells());
               for (unsigned int i=0; i<partitioning.size(); ++i)
                 partitioning(i) = this_mpi_process;
               static Vector<float> static_partitioning;

--- a/tests/error_handler/error_handler_05.cc
+++ b/tests/error_handler/error_handler_05.cc
@@ -47,7 +47,7 @@ int main ()
       eh.error_from_exact(dh, sol, Functions::CosineFunction<3>(1));
       eh.custom_error(  [&dh](unsigned int)
       {
-        return 1.0/dh.get_tria().n_active_cells();
+        return 1.0/dh.get_triangulation().n_active_cells();
       }, dh);
     }
   eh.output_table(deallog.get_file_stream());

--- a/tests/error_handler/error_handler_06.cc
+++ b/tests/error_handler/error_handler_06.cc
@@ -47,11 +47,11 @@ int main ()
       eh.error_from_exact(dh, sol, Functions::CosineFunction<3>(1));
       eh.custom_error(  [&dh](unsigned int)
       {
-        return 1.0/dh.get_tria().n_active_cells();
+        return 1.0/dh.get_triangulation().n_active_cells();
       }, dh);
       eh.custom_error(  [&dh](unsigned int)
       {
-        return 1.0/(dh.get_tria().n_active_cells()*dh.get_tria().n_active_cells());
+        return 1.0/(dh.get_triangulation().n_active_cells()*dh.get_triangulation().n_active_cells());
       }, dh, "square");
     }
   eh.output_table(deallog.get_file_stream());


### PR DESCRIPTION
```
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:212:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<1, 1>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<1,1>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:213:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<1, 2>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<1,2>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:214:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<1, 3>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<1,3>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:215:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<2, 2>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<2,2>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:216:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<2, 3>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<2,3>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:217:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<3, 3>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<3,3>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
6 warnings generated.
[25/33] Building CXX object CMakeFiles/deal2lkit.g.dir/source/parsed_data_out.cc.o
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:212:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<1, 1>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<1,1>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:213:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<1, 2>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<1,2>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:214:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<1, 3>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<1,3>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:215:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<2, 2>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<2,2>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:216:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<2, 3>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<2,3>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
                                     ^
../source/parsed_data_out.cc:148:45: warning: 'get_tria' is deprecated [-Wdeprecated-declarations]
              Vector<float> partitioning(dh.get_tria().n_active_cells());
                                            ^
../source/parsed_data_out.cc:217:27: note: in instantiation of member function 'deal2lkit::ParsedDataOut<3, 3>::prepare_data_output' requested here
template class deal2lkit::ParsedDataOut<3,3>;
                          ^
/Applications/deal.II.app/Contents/Resources/opt/deal_ii_dev/include/deal.II/dofs/dof_handler.h:804:38: note: 'get_tria' has been explicitly marked deprecated here
  const Triangulation<dim,spacedim> &get_tria () const DEAL_II_DEPRECATED;
```
