### PR TITLE
remove update bool

### DIFF
--- a/include/deal2lkit/imex_stepper.h
+++ b/include/deal2lkit/imex_stepper.h
@@ -103,9 +103,6 @@ private:
   /** Maximum number of inner iterations for Newton method. */
   unsigned int max_inner_non_linear_iterations;
 
-  /** Jacobian is updated at each outer iteration and time step */
-  bool update_jacobian_continuously;
-
 };
 
 D2K_NAMESPACE_CLOSE


### PR DESCRIPTION
I was trying to find a bug in my code and I noticed some points not clear (to me):
1. I think we can get rid of the "update" bool.
   The outer loop should always update the jacobian otherwise it is useless.
   In the case of linear problems one can set outer iterations = 1 and inner = whatever-you-want. 
2. I changed "while" with "do-while". In this way we are sure that at least one iteration is done every time.
