### PR TITLE
added missing guards

### DIFF
--- a/include/deal2lkit/parsed_preconditioner_amg.h
+++ b/include/deal2lkit/parsed_preconditioner_amg.h
@@ -16,9 +16,13 @@
 #ifndef _d2k_parsed_preconditioner_amg_h
 #define _d2k_parsed_preconditioner_amg_h
 
-#include <deal2lkit/config.h>
 #include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_TRILINOS
+
 #include <deal.II/lac/trilinos_precondition.h>
+
+#include <deal2lkit/config.h>
 #include <deal2lkit/parsed_finite_element.h>
 #include <deal2lkit/parameter_acceptor.h>
 #include <deal2lkit/utilities.h>
@@ -167,7 +171,10 @@ private:
   std::string coarse_type;
 };
 
+
 D2K_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_TRILINOS
 
 #endif
 

--- a/include/deal2lkit/parsed_preconditioner_jacobi.h
+++ b/include/deal2lkit/parsed_preconditioner_jacobi.h
@@ -16,9 +16,13 @@
 #ifndef _d2k_parsed_preconditioner_jacobi_h
 #define _d2k_parsed_preconditioner_jacobi_h
 
-#include <deal2lkit/config.h>
 #include <deal.II/base/config.h>
+
+#ifdef DEAL_II_WITH_TRILINOS
+
 #include <deal.II/lac/trilinos_precondition.h>
+
+#include <deal2lkit/config.h>
 #include <deal2lkit/parsed_finite_element.h>
 #include <deal2lkit/parameter_acceptor.h>
 #include <deal2lkit/utilities.h>
@@ -84,6 +88,8 @@ private:
 };
 
 D2K_NAMESPACE_CLOSE
+
+#endif // DEAL_II_WITH_TRILINOS
 
 #endif
 

--- a/source/parsed_preconditioner_amg.cc
+++ b/source/parsed_preconditioner_amg.cc
@@ -1,3 +1,4 @@
+
 //-----------------------------------------------------------
 //
 //    Copyright (C) 2015 by the deal2lkit authors
@@ -14,6 +15,9 @@
 //-----------------------------------------------------------
 
 #include <deal2lkit/parsed_preconditioner_amg.h>
+
+#ifdef DEAL_II_WITH_TRILINOS
+
 
 #include <deal.II/dofs/dof_tools.h>
 
@@ -214,3 +218,5 @@ template void deal2lkit::ParsedAMGPreconditioner::initialize_preconditioner<3,3,
 
 template void deal2lkit::ParsedAMGPreconditioner::initialize_preconditioner<dealii::TrilinosWrappers::SparseMatrix>(
   const dealii::TrilinosWrappers::SparseMatrix &);
+
+#endif

--- a/source/parsed_preconditioner_jacobi.cc
+++ b/source/parsed_preconditioner_jacobi.cc
@@ -15,6 +15,8 @@
 
 #include <deal2lkit/parsed_preconditioner_jacobi.h>
 
+#ifdef DEAL_II_WITH_TRILINOS
+
 D2K_NAMESPACE_OPEN
 
 ParsedJacobiPreconditioner::ParsedJacobiPreconditioner(const std::string &name,
@@ -62,3 +64,4 @@ D2K_NAMESPACE_CLOSE
 template void deal2lkit::ParsedJacobiPreconditioner::initialize_preconditioner<dealii::TrilinosWrappers::SparseMatrix>(
   const dealii::TrilinosWrappers::SparseMatrix &);
 
+#endif


### PR DESCRIPTION
should we rename these files like `parsed_trilinos_preconditioner_` ?
