### PR TITLE
fix delete_duplicated_vertices() call

### DIFF
--- a/source/assimp_interface.cc
+++ b/source/assimp_interface.cc
@@ -185,21 +185,20 @@ namespace AssimpInterface
 
     if (remove_duplicates)
       {
-        vector<unsigned int> considered_vertices;
-        GridTools::delete_duplicated_vertices(vertices, cells, subcelldata,
-                                              considered_vertices, tol);
+        // The function delete_duplicated_vertices() needs to be called more
+        // than once if a vertex is duplicated more than once. So we keep
+        // calling it until the number of vertices does not change any more.
 
-        GridTools::delete_duplicated_vertices(vertices, cells, subcelldata,
-                                              considered_vertices, tol);
-
-        GridTools::delete_duplicated_vertices(vertices, cells, subcelldata,
-                                              considered_vertices, tol);
-
-        GridTools::delete_duplicated_vertices(vertices, cells, subcelldata,
-                                              considered_vertices, tol);
-
-        GridTools::delete_duplicated_vertices(vertices, cells, subcelldata,
-                                              considered_vertices, tol);
+        // TODO: this should really be done inside
+        // GridTools::delete_duplicated_vertices
+        unsigned int n_verts = 0;
+        while (n_verts != vertices.size())
+          {
+            n_verts = vertices.size();
+            vector<unsigned int> considered_vertices;
+            GridTools::delete_duplicated_vertices(vertices, cells, subcelldata,
+                                                  considered_vertices, tol);
+          }
       }
     GridTools::delete_unused_vertices(vertices, cells, subcelldata);
     if (dim == spacedim)


### PR DESCRIPTION
- delete_duplicated_vertices reuses the considered_vertices argument but
  fails to check it to be valid. Hand in a new object every time instead.
  This avoids undefined behavior/crashes.
- keep calling delete_duplicated_vertices until no more vertices are
  deleted instead of calling it 5 times.
