### PR TITLE
silence deal.II warning inherited from PETSc

### DIFF
--- a/include/deal2lkit/error_handler.h
+++ b/include/deal2lkit/error_handler.h
@@ -41,7 +41,9 @@
 #include <deal.II/grid/grid_tools.h>
 
 #include <deal.II/numerics/vector_tools.h>
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <deal.II/numerics/matrix_tools.h>
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <deal.II/numerics/data_out.h>
 #include <deal.II/fe/mapping_q.h>
 #include <deal.II/fe/fe.h>

--- a/include/deal2lkit/utilities.h
+++ b/include/deal2lkit/utilities.h
@@ -31,6 +31,7 @@
 #include <stdio.h>
 
 #include <deal.II/lac/block_vector.h>
+DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #ifdef DEAL_II_WITH_TRILINOS
 #include <deal.II/lac/trilinos_block_vector.h>
 #include <deal.II/lac/trilinos_parallel_block_vector.h>
@@ -42,6 +43,7 @@
 #include <deal.II/lac/petsc_parallel_block_vector.h>
 #include <deal.II/lac/petsc_vector.h>
 #endif
+DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <deal.II/base/utilities.h>
 
 #ifdef D2K_WITH_SUNDIALS


### PR DESCRIPTION
```
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:805:41: warning:
      'Vector' is deprecated [-Wdeprecated-declarations]
                         PETScWrappers::Vector  &solution,
                                        ^
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:62:9: note:
      'Vector' has been explicitly marked deprecated here
  class Vector;
        ^
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:806:41: warning:
      'Vector' is deprecated [-Wdeprecated-declarations]
                         PETScWrappers::Vector  &right_hand_side,
                                        ^
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:62:9: note:
      'Vector' has been explicitly marked deprecated here
  class Vector;
        ^
In file included from /Users/esenonfossiio/git/project/pi-DoMUS/source/pidomus.cc:1:
In file included from /Users/esenonfossiio/git/project/pi-DoMUS/include/pidomus.h:36:
In file included from /Applications/deal.II.app/Contents/Resources/opt/deal2lkit-dev/include/deal2lkit/error_handler.h:44:
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:805:41: warning:
      'Vector' is deprecated [-Wdeprecated-declarations]
                         PETScWrappers::Vector  &solution,
                                        ^
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:62:9: note:
      'Vector' has been explicitly marked deprecated here
  class Vector;
        ^
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:806:41: warning:
      'Vector' is deprecated [-Wdeprecated-declarations]
                         PETScWrappers::Vector  &right_hand_side,
                                        ^
/Applications/deal.II.app/Contents/Resources/opt/dealii_dev/include/deal.II/numerics/matrix_tools.h:62:9: note:
      'Vector' has been explicitly marked deprecated here
  class Vector;
```
