### PR TITLE
added support for section/subsection

### DIFF
--- a/doxygen/headers/changes.h
+++ b/doxygen/headers/changes.h
@@ -100,6 +100,11 @@ preconditioner couplings and related variables and methods.
 
 <ol>
   <li> 
+  New: ParameterAcceptor can handle section and subsection.
+  <br>
+  (Alberto Sartori 2016/06/01)
+  </li>
+  <li> 
   New: The function set_initial_time() has been implemented for
  IMEXStepper and IDAInterface.
   <br>

--- a/source/parameter_acceptor.cc
+++ b/source/parameter_acceptor.cc
@@ -123,7 +123,6 @@ void ParameterAcceptor::parse_all_parameters(ParameterHandler &prm)
       {
         std::vector<std::string> secs;
         secs = Utilities::split_string_list(class_list[i]->get_section_name(), sep);
-        std::cout << "secs" << secs[0] << std::endl;
         const unsigned int secs_size = secs.size();
 
         if (secs_size == 1) // add a subsection with relative path

--- a/tests/error_handler/error_handler_03.cc
+++ b/tests/error_handler/error_handler_03.cc
@@ -27,7 +27,7 @@ int main ()
 {
   initlog();
 
-  ErrorHandler<> eh(" ", "u, u, p","L2, Linfty, H1; AddUp; L2"); // Only one table
+  ErrorHandler<> eh("", "u, u, p","L2, Linfty, H1; AddUp; L2"); // Only one table
 
   ParameterAcceptor::initialize();
   ParameterAcceptor::prm.log_parameters(deallog);

--- a/tests/error_handler/error_handler_03.output
+++ b/tests/error_handler/error_handler_03.output
@@ -1,14 +1,14 @@
 
-DEAL:parameters: ::Compute error: true
-DEAL:parameters: ::Error file format: tex
-DEAL:parameters: ::Error precision: 3
-DEAL:parameters: ::Output error tables: true
-DEAL:parameters: ::Solution names: u, u, p
-DEAL:parameters: ::Solution names for latex: u, u, p
-DEAL:parameters: ::Table names: error
-DEAL:parameters: ::Write error files: false
-DEAL:parameters: :Table 0::Add convergence rates: true
-DEAL:parameters: :Table 0::Extra terms: cells,dofs
-DEAL:parameters: :Table 0::Latex table caption: error
-DEAL:parameters: :Table 0::List of error norms to compute: L2, Linfty, H1; AddUp; L2
-DEAL:parameters: :Table 0::Rate key: 
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Compute error: true
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Error file format: tex
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Error precision: 3
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Output error tables: true
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Solution names: u, u, p
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Solution names for latex: u, u, p
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Table names: error
+DEAL:parameters:deal2lkit::ErrorHandler<1>::Write error files: false
+DEAL:parameters:deal2lkit::ErrorHandler<1>:Table 0::Add convergence rates: true
+DEAL:parameters:deal2lkit::ErrorHandler<1>:Table 0::Extra terms: cells,dofs
+DEAL:parameters:deal2lkit::ErrorHandler<1>:Table 0::Latex table caption: error
+DEAL:parameters:deal2lkit::ErrorHandler<1>:Table 0::List of error norms to compute: L2, Linfty, H1; AddUp; L2
+DEAL:parameters:deal2lkit::ErrorHandler<1>:Table 0::Rate key: 


### PR DESCRIPTION
if the string given to the constructor of ParameterAcceptor has the syntax

```
AAAAAA:class name
```

it will create in the parameter file

```
subsection AAAAAAA
   subsection class name
      set ....
      .....
    end
end
```

if the design of our classes is as follows

```
class Base : public ParameterAcceptor
{
 Base();

ParsedFunction f;
ParsedGridGenerator pgg;
};

Base::Base() :
  ParameterAcceptor("First section: Base")
f("funzione di Base")
pgg("PGG of Base"){};
```

I will have the subsection "funzione di Base" and "PGG of Base" **within** the section "First section".
