### PR TITLE
Global parameter acceptor.

### DIFF
--- a/include/deal2lkit/parameter_acceptor.h
+++ b/include/deal2lkit/parameter_acceptor.h
@@ -434,8 +434,19 @@ public:
    * may want to overload this function. If you want to make sure the
    * automatic assignement of variables work, you should fill this
    * function only with calls to the add_parameter() method.
+   *
+   * Alternatively, you could insert your calls to the add_parameter()
+   * function that takes three arguments directly in the constructor.
+   *
+   * In this case, the ParameterAcceptor::prm parameter handler is used
+   * by default, and you don't need to overload this function. The default
+   * implementation in fact does nothing.
+   *
+   * In general this approach is here to guarantee backward compatibility
+   * with the strategy advocated by the \dealii library of splitting declaration
+   * and parsing of parameters into two functions.
    */
-  virtual void declare_parameters(ParameterHandler &prm) {};
+  virtual void declare_parameters(ParameterHandler &) {};
 
 
   /**

--- a/tests/parameter_acceptor/global_parameter_acceptor_01.cc
+++ b/tests/parameter_acceptor/global_parameter_acceptor_01.cc
@@ -1,0 +1,50 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal2lkit authors
+//
+//    This file is part of the deal2lkit library.
+//
+//    The deal2lkit library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal2lkit distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal2lkit/utilities.h>
+#include <deal2lkit/parameter_acceptor.h>
+
+
+using namespace deal2lkit;
+
+class MyClass : public ParameterAcceptor
+{
+public:
+  MyClass(const std::string &name = "My Class",
+          const unsigned int &i=0):
+    ParameterAcceptor(name),
+    i(i)
+  {
+    add_parameter(this->i, "An integer");
+  };
+
+private:
+  unsigned int i;
+};
+
+int main ()
+{
+  initlog();
+
+  MyClass  f0("One", 1);
+  MyClass  f1("Two", 2);
+  MyClass  f2("Three", 3);
+
+  ParameterAcceptor::prm.log_parameters(deallog);
+}

--- a/tests/parameter_acceptor/global_parameter_acceptor_01.output
+++ b/tests/parameter_acceptor/global_parameter_acceptor_01.output
@@ -1,0 +1,4 @@
+
+DEAL:parameters:One::An integer: 1
+DEAL:parameters:Three::An integer: 3
+DEAL:parameters:Two::An integer: 2

--- a/tests/parameter_acceptor/global_parameter_acceptor_02.cc
+++ b/tests/parameter_acceptor/global_parameter_acceptor_02.cc
@@ -27,10 +27,11 @@ template<class T>
 class TemplateClass : public ParameterAcceptor
 {
 public:
-  TemplateClass(const T &i=T()):
+  TemplateClass(const T &i, const std::string &var):
+    ParameterAcceptor("Class<"+var+" >"),
     t(i)
   {
-    add_parameter(t, type(t));
+    add_parameter(t, var);
   };
 
 private:
@@ -41,27 +42,27 @@ int main ()
 {
   initlog();
 
-  TemplateClass<std::string  > f00("ciao"         );
-  TemplateClass<int          > f01(-1             );
-  TemplateClass<unsigned int > f02(1              );
-  TemplateClass<double       > f03(1e-4           );
-  TemplateClass<bool         > f04(false          );
-  TemplateClass<Point<1>     > f05(Point<1>(0)    );
-  TemplateClass<Point<2>     > f06(Point<2>(0,1)  );
-  TemplateClass<Point<3>     > f07(Point<3>(0,1,2));
+  TemplateClass<std::string  > f00("ciao"         ,"std::string");
+  TemplateClass<int          > f01(-1             ,"int");
+  TemplateClass<unsigned int > f02(1              ,"unsigned int");
+  TemplateClass<double       > f03(1e-4           ,"double");
+  TemplateClass<bool         > f04(false          ,"bool");
+  TemplateClass<Point<1>     > f05(Point<1>(0)    ,"Point<1>");
+  TemplateClass<Point<2>     > f06(Point<2>(0,1)  ,"Point<2>");
+  TemplateClass<Point<3>     > f07(Point<3>(0,1,2),"Point<3>");
 
-  TemplateClass<std::vector<std::string  > > f10(std::vector<std::string  >(3, "ciao"          ));
-  TemplateClass<std::vector<int          > > f11(std::vector<int          >(3, -1              ));
-  TemplateClass<std::vector<unsigned int > > f12(std::vector<unsigned int >(3, 1               ));
-  TemplateClass<std::vector<double       > > f13(std::vector<double       >(3, 1e-4            ));
-  TemplateClass<std::vector<Point<1>     > > f15(std::vector<Point<1>     >(3, Point<1>(0)     ));
-  TemplateClass<std::vector<Point<2>     > > f16(std::vector<Point<2>     >(3, Point<2>(0,1)   ));
-  TemplateClass<std::vector<Point<3>     > > f17(std::vector<Point<3>     >(3, Point<3>(0,1,2) ));
+  TemplateClass<std::vector<std::string  > > f10(std::vector<std::string  >(3, "ciao"          ),"std::vector<std::string>");
+  TemplateClass<std::vector<int          > > f11(std::vector<int          >(3, -1              ),"std::vector<int>");
+  TemplateClass<std::vector<unsigned int > > f12(std::vector<unsigned int >(3, 1               ),"std::vector<unsigned int>");
+  TemplateClass<std::vector<double       > > f13(std::vector<double       >(3, 1e-4            ),"std::vector<double>");
+  TemplateClass<std::vector<Point<1>     > > f15(std::vector<Point<1>     >(3, Point<1>(0)     ),"std::vector<Point<1>>");
+  TemplateClass<std::vector<Point<2>     > > f16(std::vector<Point<2>     >(3, Point<2>(0,1)   ),"std::vector<Point<2>>");
+  TemplateClass<std::vector<Point<3>     > > f17(std::vector<Point<3>     >(3, Point<3>(0,1,2) ),"std::vector<Point<3>>");
 
-  TemplateClass<std::vector<std::vector<std::string  > > > f110(std::vector<std::vector<std::string  > >(2, std::vector<std::string  >(3, "ciao" )));
-  TemplateClass<std::vector<std::vector<int          > > > f111(std::vector<std::vector<int          > >(2, std::vector<int          >(3, -1     )));
-  TemplateClass<std::vector<std::vector<unsigned int > > > f112(std::vector<std::vector<unsigned int > >(2, std::vector<unsigned int >(3, 1      )));
-  TemplateClass<std::vector<std::vector<double       > > > f113(std::vector<std::vector<double       > >(2, std::vector<double       >(3, 1e-4   )));
+  TemplateClass<std::vector<std::vector<std::string  > > > f110(std::vector<std::vector<std::string  > >(2, std::vector<std::string  >(3, "ciao" )), "std::vector<std::vector<std::string>>");
+  TemplateClass<std::vector<std::vector<int          > > > f111(std::vector<std::vector<int          > >(2, std::vector<int          >(3, -1     )), "std::vector<std::vector<int>>");
+  TemplateClass<std::vector<std::vector<unsigned int > > > f112(std::vector<std::vector<unsigned int > >(2, std::vector<unsigned int >(3, 1      )), "std::vector<std::vector<unsigned int>>");
+  TemplateClass<std::vector<std::vector<double       > > > f113(std::vector<std::vector<double       > >(2, std::vector<double       >(3, 1e-4   )), "std::vector<std::vector<double>>");
 
   std::system("rm -f parameters.prm");
   // The first round is here to create the file parameters.prm with default values

--- a/tests/parameter_acceptor/global_parameter_acceptor_02.cc
+++ b/tests/parameter_acceptor/global_parameter_acceptor_02.cc
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal2lkit authors
+//
+//    This file is part of the deal2lkit library.
+//
+//    The deal2lkit library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal2lkit distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal2lkit/utilities.h>
+#include <deal2lkit/parameter_acceptor.h>
+
+
+using namespace deal2lkit;
+
+template<class T>
+class TemplateClass : public ParameterAcceptor
+{
+public:
+  TemplateClass(const T &i=T()):
+    t(i)
+  {
+    add_parameter(t, type(t));
+  };
+
+private:
+  T t;
+};
+
+int main ()
+{
+  initlog();
+
+  TemplateClass<std::string  > f00("ciao"         );
+  TemplateClass<int          > f01(-1             );
+  TemplateClass<unsigned int > f02(1              );
+  TemplateClass<double       > f03(1e-4           );
+  TemplateClass<bool         > f04(false          );
+  TemplateClass<Point<1>     > f05(Point<1>(0)    );
+  TemplateClass<Point<2>     > f06(Point<2>(0,1)  );
+  TemplateClass<Point<3>     > f07(Point<3>(0,1,2));
+
+  TemplateClass<std::vector<std::string  > > f10(std::vector<std::string  >(3, "ciao"          ));
+  TemplateClass<std::vector<int          > > f11(std::vector<int          >(3, -1              ));
+  TemplateClass<std::vector<unsigned int > > f12(std::vector<unsigned int >(3, 1               ));
+  TemplateClass<std::vector<double       > > f13(std::vector<double       >(3, 1e-4            ));
+  TemplateClass<std::vector<Point<1>     > > f15(std::vector<Point<1>     >(3, Point<1>(0)     ));
+  TemplateClass<std::vector<Point<2>     > > f16(std::vector<Point<2>     >(3, Point<2>(0,1)   ));
+  TemplateClass<std::vector<Point<3>     > > f17(std::vector<Point<3>     >(3, Point<3>(0,1,2) ));
+
+  TemplateClass<std::vector<std::vector<std::string  > > > f110(std::vector<std::vector<std::string  > >(2, std::vector<std::string  >(3, "ciao" )));
+  TemplateClass<std::vector<std::vector<int          > > > f111(std::vector<std::vector<int          > >(2, std::vector<int          >(3, -1     )));
+  TemplateClass<std::vector<std::vector<unsigned int > > > f112(std::vector<std::vector<unsigned int > >(2, std::vector<unsigned int >(3, 1      )));
+  TemplateClass<std::vector<std::vector<double       > > > f113(std::vector<std::vector<double       > >(2, std::vector<double       >(3, 1e-4   )));
+
+  std::system("rm -f parameters.prm");
+  // The first round is here to create the file parameters.prm with default values
+  ParameterAcceptor::initialize("parameters.prm");
+  // This is here to read the default values just created.
+  ParameterAcceptor::initialize("parameters.prm");
+  ParameterAcceptor::prm.log_parameters(deallog);
+}

--- a/tests/parameter_acceptor/global_parameter_acceptor_02.output
+++ b/tests/parameter_acceptor/global_parameter_acceptor_02.output
@@ -1,8 +1,20 @@
 
-DEAL:parameters:TemplateClass<bool>::bool: false
-DEAL:parameters:TemplateClass<dealii::Point<1, double> >::dealii::Point<1, double>: 0
-DEAL:parameters:TemplateClass<dealii::Point<2, double> >::dealii::Point<2, double>: 0,1
-DEAL:parameters:TemplateClass<dealii::Point<3, double> >::dealii::Point<3, double>: 0,1,2
-DEAL:parameters:TemplateClass<double>::double: 0.000100
-DEAL:parameters:TemplateClass<int>::int: -1
-DEAL:parameters:TemplateClass<unsigned int>::unsigned int: 1
+DEAL:parameters:Class<Point<1>>::Point<1>: 0
+DEAL:parameters:Class<Point<2>>::Point<2>: 0,1
+DEAL:parameters:Class<Point<3>>::Point<3>: 0,1,2
+DEAL:parameters:Class<bool>::bool: false
+DEAL:parameters:Class<double>::double: 0.000100
+DEAL:parameters:Class<int>::int: -1
+DEAL:parameters:Class<std::string>::std::string: ciao
+DEAL:parameters:Class<std::vector<Point<1>>>::std::vector<Point<1>>: 0; 0; 0
+DEAL:parameters:Class<std::vector<Point<2>>>::std::vector<Point<2>>: 0,1; 0,1; 0,1
+DEAL:parameters:Class<std::vector<Point<3>>>::std::vector<Point<3>>: 0,1,2; 0,1,2; 0,1,2
+DEAL:parameters:Class<std::vector<double>>::std::vector<double>: 0.000100, 0.000100, 0.000100
+DEAL:parameters:Class<std::vector<int>>::std::vector<int>: -1, -1, -1
+DEAL:parameters:Class<std::vector<std::string>>::std::vector<std::string>: ciao, ciao, ciao
+DEAL:parameters:Class<std::vector<std::vector<double>>>::std::vector<std::vector<double>>: 0.000100, 0.000100, 0.000100; 0.000100, 0.000100, 0.000100
+DEAL:parameters:Class<std::vector<std::vector<int>>>::std::vector<std::vector<int>>: -1, -1, -1; -1, -1, -1
+DEAL:parameters:Class<std::vector<std::vector<std::string>>>::std::vector<std::vector<std::string>>: ciao, ciao, ciao; ciao, ciao, ciao
+DEAL:parameters:Class<std::vector<std::vector<unsigned int>>>::std::vector<std::vector<unsigned int>>: 1, 1, 1; 1, 1, 1
+DEAL:parameters:Class<std::vector<unsigned int>>::std::vector<unsigned int>: 1, 1, 1
+DEAL:parameters:Class<unsigned int>::unsigned int: 1

--- a/tests/parameter_acceptor/global_parameter_acceptor_02.output
+++ b/tests/parameter_acceptor/global_parameter_acceptor_02.output
@@ -1,0 +1,8 @@
+
+DEAL:parameters:TemplateClass<bool>::bool: false
+DEAL:parameters:TemplateClass<dealii::Point<1, double> >::dealii::Point<1, double>: 0
+DEAL:parameters:TemplateClass<dealii::Point<2, double> >::dealii::Point<2, double>: 0,1
+DEAL:parameters:TemplateClass<dealii::Point<3, double> >::dealii::Point<3, double>: 0,1,2
+DEAL:parameters:TemplateClass<double>::double: 0.000100
+DEAL:parameters:TemplateClass<int>::int: -1
+DEAL:parameters:TemplateClass<unsigned int>::unsigned int: 1

--- a/tests/parameter_acceptor/global_parameter_acceptor_03.cc
+++ b/tests/parameter_acceptor/global_parameter_acceptor_03.cc
@@ -1,0 +1,82 @@
+//-----------------------------------------------------------
+//
+//    Copyright (C) 2015 by the deal2lkit authors
+//
+//    This file is part of the deal2lkit library.
+//
+//    The deal2lkit library is free software; you can use it, redistribute
+//    it, and/or modify it under the terms of the GNU Lesser General
+//    Public License as published by the Free Software Foundation; either
+//    version 2.1 of the License, or (at your option) any later version.
+//    The full text of the license can be found in the file LICENSE at
+//    the top level of the deal2lkit distribution.
+//
+//-----------------------------------------------------------
+
+
+
+#include "../tests.h"
+#include <deal.II/base/path_search.h>
+#include <deal2lkit/utilities.h>
+#include <deal2lkit/parameter_acceptor.h>
+
+
+using namespace deal2lkit;
+
+class MyClass : public ParameterAcceptor
+{
+public:
+  MyClass(const std::string &name = "My Class",
+          const unsigned int &i=0):
+    ParameterAcceptor(name+std::to_string(c++)),
+    i(i)
+  {
+    add_parameter(this->i, "An integer");
+  };
+
+private:
+  unsigned int i;
+  static unsigned int c;
+};
+
+unsigned int MyClass::c=0;
+
+class MyMasterClass : public ParameterAcceptor
+{
+public:
+  MyMasterClass(const std::string &name = "MyMasterClass",
+                const double &d=0):
+    ParameterAcceptor(name),
+    d(d),
+    mc("Slave", 1)
+  {
+    add_parameter(this->d, "A double");
+  };
+
+private:
+  double d;
+  MyClass mc;
+};
+
+
+int main ()
+{
+  initlog();
+
+  MyMasterClass  f00("/");
+  MyMasterClass  f0("Relative");
+  MyMasterClass  f1("RelativeTraling/");
+  MyMasterClass  f2("/Absolute");
+  MyMasterClass  f3("/AbsoluteTrailing/");
+  MyMasterClass  f4("/AbsoluteNested/Class");
+  MyMasterClass  f5("/AbsoluteNested/ClassTrailing/");
+
+  std::string test = "/AbsoluteTrailing/";
+  auto l = Utilities::split_string_list(test, '/');
+  deallog << l.size() << std::endl;
+  for (auto s: l)
+    deallog << s << std::endl;
+
+  ParameterAcceptor::log_info();
+  ParameterAcceptor::prm.log_parameters(deallog);
+}

--- a/tests/parameter_acceptor/global_parameter_acceptor_03.output
+++ b/tests/parameter_acceptor/global_parameter_acceptor_03.output
@@ -1,0 +1,32 @@
+
+DEAL::2
+DEAL::
+DEAL::AbsoluteTrailing
+DEAL:ParameterAcceptor::Class 0:/
+DEAL:ParameterAcceptor::Class 1:Slave0
+DEAL:ParameterAcceptor::Class 2:Relative
+DEAL:ParameterAcceptor::Class 3:Slave1
+DEAL:ParameterAcceptor::Class 4:RelativeTraling/
+DEAL:ParameterAcceptor::Class 5:Slave2
+DEAL:ParameterAcceptor::Class 6:/Absolute
+DEAL:ParameterAcceptor::Class 7:Slave3
+DEAL:ParameterAcceptor::Class 8:/AbsoluteTrailing/
+DEAL:ParameterAcceptor::Class 9:Slave4
+DEAL:ParameterAcceptor::Class 10:/AbsoluteNested/Class
+DEAL:ParameterAcceptor::Class 11:Slave5
+DEAL:ParameterAcceptor::Class 12:/AbsoluteNested/ClassTrailing/
+DEAL:ParameterAcceptor::Class 13:Slave6
+DEAL:parameters::A double: 0.000000
+DEAL:parameters:Absolute::A double: 0.000000
+DEAL:parameters:AbsoluteNested:Class::A double: 0.000000
+DEAL:parameters:AbsoluteNested:ClassTrailing::A double: 0.000000
+DEAL:parameters:AbsoluteNested:ClassTrailing:Slave6::An integer: 1
+DEAL:parameters:AbsoluteNested:Slave5::An integer: 1
+DEAL:parameters:AbsoluteTrailing::A double: 0.000000
+DEAL:parameters:AbsoluteTrailing:Slave4::An integer: 1
+DEAL:parameters:Relative::A double: 0.000000
+DEAL:parameters:RelativeTraling::A double: 0.000000
+DEAL:parameters:Slave0::An integer: 1
+DEAL:parameters:Slave1::An integer: 1
+DEAL:parameters:Slave2::An integer: 1
+DEAL:parameters:Slave3::An integer: 1


### PR DESCRIPTION
Now it is possible to initialize a class in an even simpler way:

~~~

class MyClass : public ParameterAcceptor
{
public:
  MyClass(const std::string &name = "My Class",
          const unsigned int &i=0):
    ParameterAcceptor(name),
    i(i)
  {
    add_parameter(this->i, "An integer");
  };

  void run() {
    ...
  }

private:
  unsigned int i;
}


int main ()
{
  MyClass  f;
  ParameterAcceptor::initialize("parameters.prm");
  f.run();
}
~~~

Will work out of the box, without requiring a `declare_parameter` function, as long as `add_parameter` is used in the constructor. This version of `add_parameter` can only use the global parameter handler `ParameterAcceptor::prm`.

