### PR TITLE
free vectors in the destructor

### DIFF
--- a/source/kinsol_interface.cc
+++ b/source/kinsol_interface.cc
@@ -190,6 +190,13 @@ KINSOLInterface<VEC>::~KINSOLInterface()
     KINFree(&kin_mem);
 #ifdef DEAL_II_WITH_MPI
   MPI_Comm_free(&communicator);
+  if (solution) N_VDestroy_Parallel(solution);
+  if (u_scale) N_VDestroy_Parallel(u_scale);
+  if (f_scale) N_VDestroy_Parallel(f_scale);
+#else
+  if (solution) N_VDestroy_Serial(solution);
+  if (u_scale) N_VDestroy_Serial(u_scale);
+  if (f_scale) N_VDestroy_Serial(f_scale);
 #endif
 }
 
@@ -389,15 +396,7 @@ int KINSOLInterface<VEC>::solve( VEC &sol )
   AssertThrow(status >= 0 , ExcMessage("KINSOL did not converge. You might try with a different strategy."));
 
   copy( sol, this->solution );
-#ifdef DEAL_II_WITH_MPI
-  if (solution) N_VDestroy_Parallel(solution);
-  if (u_scale) N_VDestroy_Parallel(u_scale);
-  if (f_scale) N_VDestroy_Parallel(f_scale);
-#else
-  if (solution) N_VDestroy_Serial(solution);
-  if (u_scale) N_VDestroy_Serial(u_scale);
-  if (f_scale) N_VDestroy_Serial(f_scale);
-#endif
+
   return status;
 
 }


### PR DESCRIPTION
In the previous PR I introduced a bug. The vectors were freed too early. This fixes the bug