### PR TITLE
Fixed compatibility with dev version (hyperball template & unique_ptr)

### DIFF
--- a/include/deal2lkit/parsed_finite_element.h
+++ b/include/deal2lkit/parsed_finite_element.h
@@ -136,7 +136,7 @@ public:
    * different from the number of components given at construction
    * time.
    */
-  FiniteElement<dim, spacedim> *operator() () const;
+  std::unique_ptr< FiniteElement<dim,spacedim> > operator() () const;
 
   /**
    * Fill information about blocks after parsing the parameters.

--- a/source/parsed_finite_element.cc
+++ b/source/parsed_finite_element.cc
@@ -62,7 +62,7 @@ void ParsedFiniteElement<dim, spacedim>::declare_parameters(ParameterHandler &pr
 }
 
 template <int dim, int spacedim>
-FiniteElement<dim,spacedim> *
+std::unique_ptr< FiniteElement<dim,spacedim> >
 ParsedFiniteElement<dim, spacedim>::operator()() const
 {
   return FETools::get_fe_by_name<dim,spacedim>(fe_name);
@@ -83,9 +83,9 @@ void ParsedFiniteElement<dim,spacedim>::parse_parameters_call_back()
       block_names[j] = component_names[i];
     }
   block_names.resize(j+1);
-  FiniteElement<dim,spacedim> *fe = (*this)();
+  std::unique_ptr< FiniteElement<dim,spacedim> > fe = (*this)();
   const unsigned int nc = fe->n_components();
-  delete fe;
+  fe.reset();
   AssertThrow(component_names.size() == nc,
               ExcInternalError("Generated FE has the wrong number of components."));
 }

--- a/source/parsed_grid_generator.cc
+++ b/source/parsed_grid_generator.cc
@@ -455,9 +455,11 @@ struct PGGHelper
   {
     if (p->grid_name == "hyper_sphere")
       {
-        GridGenerator::hyper_sphere<dim,dim+1> ( tria,
-                                                 p->point_option_one,
-                                                 p->double_option_one);
+        // deal.II hyper_sphere dev requires only spacedim as template
+        // argument, but it can use "tria" to find the templated values
+        GridGenerator::hyper_sphere ( tria,
+                                      p->point_option_one,
+                                      p->double_option_one);
         if (p->create_default_manifolds)
           tria.set_all_manifold_ids(0);
         p->default_manifold_descriptors = "0=SphericalManifold";


### PR DESCRIPTION
In the end I believe this is the best way to maintain compatibility with both old and new versions of the library, at least for HyberBall (but it should be thoroughly tested).

I'll now try to fix the pointer problem!