### PR TITLE
Using namespace only in cc files.

### DIFF
--- a/include/deal2lkit/any_data.h
+++ b/include/deal2lkit/any_data.h
@@ -31,7 +31,6 @@
 #include <typeinfo>
 #include <vector>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -64,7 +63,7 @@ D2K_NAMESPACE_OPEN
  * @endcode
  */
 
-class AnyData : public Subscriptor
+class AnyData : public dealii::Subscriptor
 {
 public:
   /**

--- a/include/deal2lkit/config.h.in
+++ b/include/deal2lkit/config.h.in
@@ -17,7 +17,6 @@
 #ifndef _d2k_config_h
 #define _d2k_config_h
 
-
 /***********************************************************************
  * Information about deal2lkit:
  */

--- a/include/deal2lkit/dof_utilities.h
+++ b/include/deal2lkit/dof_utilities.h
@@ -28,8 +28,6 @@
 #include <sstream>
 #include <typeinfo>
 
-using namespace dealii;
-
 
 
 /**
@@ -58,9 +56,9 @@ namespace DOFUtilities
   template <typename Number, typename VEC>
   void
   extract_local_dofs(
-    const VEC &                                 global_vector,
-    const std::vector<types::global_dof_index> &local_dof_indices,
-    std::vector<Number> &                       independent_local_dofs)
+    const VEC &                                         global_vector,
+    const std::vector<dealii::types::global_dof_index> &local_dof_indices,
+    std::vector<Number> &                               independent_local_dofs)
   {
     AssertDimension(local_dof_indices.size(), independent_local_dofs.size());
 
@@ -90,7 +88,7 @@ namespace DOFUtilities
 #endif
         else
           {
-            Assert(false, ExcNotImplemented());
+            Assert(false, dealii::ExcNotImplemented());
           }
       }
   }
@@ -104,9 +102,9 @@ namespace DOFUtilities
    */
   template <int dim, int spacedim, typename Number>
   void
-  get_values(const FEValuesBase<dim, spacedim> &fe_values,
-             const std::vector<Number> &        independent_local_dof_values,
-             std::vector<std::vector<Number>> & us)
+  get_values(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+             const std::vector<Number> &       independent_local_dof_values,
+             std::vector<std::vector<Number>> &us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -123,7 +121,7 @@ namespace DOFUtilities
         for (unsigned int i = 0; i < dofs_per_cell; ++i)
           for (unsigned int j = 0; j < n_components; ++j)
             {
-              FEValuesExtractors::Scalar s(j);
+              dealii::FEValuesExtractors::Scalar s(j);
               us[q][j] +=
                 independent_local_dof_values[i] * fe_values[s].value(i, q);
             }
@@ -133,17 +131,17 @@ namespace DOFUtilities
   /**
    *  Extract independent local dofs values of a vector_variable
    *  in a cell and store them in
-   *  std::vector<Tensor<1,spacedim,Number>> us
+   *  std::vector<dealii::Tensor<1,spacedim,Number>> us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
 
   void
-  get_values(const FEValuesBase<dim, spacedim> &fe_values,
-             const std::vector<Number> &        independent_local_dof_values,
-             const FEValuesExtractors::Vector & vector_variable,
-             std::vector<Tensor<1, spacedim, Number>> &us)
+  get_values(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+             const std::vector<Number> &independent_local_dof_values,
+             const dealii::FEValuesExtractors::Vector &        vector_variable,
+             std::vector<dealii::Tensor<1, spacedim, Number>> &us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -172,10 +170,10 @@ namespace DOFUtilities
    */
   template <int dim, int spacedim, typename Number>
   void
-  get_values(const FEValuesBase<dim, spacedim> &fe_values,
-             const std::vector<Number> &        independent_local_dof_values,
-             const FEValuesExtractors::Scalar & scalar_variable,
-             std::vector<Number> &              us)
+  get_values(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+             const std::vector<Number> &independent_local_dof_values,
+             const dealii::FEValuesExtractors::Scalar &scalar_variable,
+             std::vector<Number> &                     us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -203,10 +201,10 @@ namespace DOFUtilities
    */
   template <int dim, int spacedim, typename Number>
   void
-  get_divergences(const FEValuesBase<dim, spacedim> &fe_values,
+  get_divergences(const dealii::FEValuesBase<dim, spacedim> &fe_values,
                   const std::vector<Number> &independent_local_dof_values,
-                  const FEValuesExtractors::Vector &vector_variable,
-                  std::vector<Number> &             us)
+                  const dealii::FEValuesExtractors::Vector &vector_variable,
+                  std::vector<Number> &                     us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -228,16 +226,16 @@ namespace DOFUtilities
   /**
    *  Extract gradient values of a vector_variable
    *  on face of a cell and store them in
-   *  std::vector <Tensor <2, spacedim, Number> > grad_us
+   *  std::vector <dealii::Tensor <2, spacedim, Number> > grad_us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
   void
-  get_gradients(const FEValuesBase<dim, spacedim> &fe_values,
-                const std::vector<Number> &        independent_local_dof_values,
-                const FEValuesExtractors::Vector & vector_variable,
-                std::vector<Tensor<2, spacedim, Number>> &grad_us)
+  get_gradients(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+                const std::vector<Number> &independent_local_dof_values,
+                const dealii::FEValuesExtractors::Vector &vector_variable,
+                std::vector<dealii::Tensor<2, spacedim, Number>> &grad_us)
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
     const unsigned int n_q_points    = fe_values.n_quadrature_points;
@@ -262,17 +260,18 @@ namespace DOFUtilities
   /**
    *  Extract curl values of a vector_variable
    *  on face or cell and store them in
-   *  std::vector <Tensor <1, spacedim, Number> > curl_us
+   *  std::vector <dealii::Tensor <1, spacedim, Number> > curl_us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
   void
   get_curls(
-    const FEValuesBase<dim, spacedim> &fe_values,
-    const std::vector<Number> &        independent_local_dof_values,
-    const FEValuesExtractors::Vector & vector_variable,
-    std::vector<Tensor<1, (spacedim > 2 ? spacedim : 1), Number>> &curl_us)
+    const dealii::FEValuesBase<dim, spacedim> &fe_values,
+    const std::vector<Number> &                independent_local_dof_values,
+    const dealii::FEValuesExtractors::Vector & vector_variable,
+    std::vector<dealii::Tensor<1, (spacedim > 2 ? spacedim : 1), Number>>
+      &curl_us)
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
     const unsigned int n_q_points    = fe_values.n_quadrature_points;
@@ -297,16 +296,16 @@ namespace DOFUtilities
   /**
    *  Extract gradient values of a scalar_variable
    *  on face of a cell and store them in
-   *  std::vector <Tensor <1, spacedim, Number> > grad_us
+   *  std::vector <dealii::Tensor <1, spacedim, Number> > grad_us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
   void
-  get_gradients(const FEValuesBase<dim, spacedim> &fe_values,
-                const std::vector<Number> &        independent_local_dof_values,
-                const FEValuesExtractors::Scalar & scalar_variable,
-                std::vector<Tensor<1, spacedim, Number>> &grad_us)
+  get_gradients(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+                const std::vector<Number> &independent_local_dof_values,
+                const dealii::FEValuesExtractors::Scalar &scalar_variable,
+                std::vector<dealii::Tensor<1, spacedim, Number>> &grad_us)
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
     const unsigned int n_q_points    = fe_values.n_quadrature_points;
@@ -329,17 +328,17 @@ namespace DOFUtilities
   /**
    *  Compute the deformation gradient in each quadrature point
    *  of a cell and it is stored in
-   *  std::vector <Tensor <2, spacedim, Number> > Fs
+   *  std::vector <dealii::Tensor <2, spacedim, Number> > Fs
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
   void
   get_deformation_gradients(
-    const FEValuesBase<dim, spacedim> &       fe_values,
-    const std::vector<Number> &               independent_local_dof_values,
-    const FEValuesExtractors::Vector &        vector_variable,
-    std::vector<Tensor<2, spacedim, Number>> &Fs)
+    const dealii::FEValuesBase<dim, spacedim> &fe_values,
+    const std::vector<Number> &                independent_local_dof_values,
+    const dealii::FEValuesExtractors::Vector & vector_variable,
+    std::vector<dealii::Tensor<2, spacedim, Number>> &Fs)
   {
     const unsigned int n_q_points = fe_values.n_quadrature_points;
 
@@ -358,17 +357,17 @@ namespace DOFUtilities
   /**
    *  Extract symmetric gradient values of a vector_variable
    *  on face of a cell and store them in
-   *  std::vector <Tensor <2, spacedim, Number> > grad_us
+   *  std::vector <dealii::Tensor <2, spacedim, Number> > grad_us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
   void
   get_symmetric_gradients(
-    const FEValuesBase<dim, spacedim> &       fe_values,
-    const std::vector<Number> &               independent_local_dof_values,
-    const FEValuesExtractors::Vector &        vector_variable,
-    std::vector<Tensor<2, spacedim, Number>> &grad_us)
+    const dealii::FEValuesBase<dim, spacedim> &fe_values,
+    const std::vector<Number> &                independent_local_dof_values,
+    const dealii::FEValuesExtractors::Vector & vector_variable,
+    std::vector<dealii::Tensor<2, spacedim, Number>> &grad_us)
   {
     const unsigned int n_q_points = fe_values.n_quadrature_points;
 
@@ -396,10 +395,10 @@ namespace DOFUtilities
   template <int dim, int spacedim, typename Number>
 
   void
-  get_laplacians(const FEValuesBase<dim, spacedim> &fe_values,
-                 const std::vector<Number> &       independent_local_dof_values,
-                 const FEValuesExtractors::Scalar &variable,
-                 std::vector<Number> &             us)
+  get_laplacians(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+                 const std::vector<Number> &independent_local_dof_values,
+                 const dealii::FEValuesExtractors::Scalar &variable,
+                 std::vector<Number> &                     us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -421,17 +420,17 @@ namespace DOFUtilities
   /**
    *  Extract laplacians local dofs values of a vector variable
    *  in a cell and store them in
-   *  std::vector <Tensor<1,Number > > us
+   *  std::vector <dealii::Tensor<1,Number > > us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
 
   void
-  get_laplacians(const FEValuesBase<dim, spacedim> &fe_values,
-                 const std::vector<Number> &       independent_local_dof_values,
-                 const FEValuesExtractors::Vector &variable,
-                 std::vector<Tensor<1, spacedim, Number>> &us)
+  get_laplacians(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+                 const std::vector<Number> &independent_local_dof_values,
+                 const dealii::FEValuesExtractors::Vector &        variable,
+                 std::vector<dealii::Tensor<1, spacedim, Number>> &us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -453,17 +452,17 @@ namespace DOFUtilities
   /**
    *  Extract hessians local dofs values of a scalar variable
    *  in a cell and store them in
-   *  std::vector <Tensor<2,Number > > us
+   *  std::vector <dealii::Tensor<2,Number > > us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
 
   void
-  get_hessians(const FEValuesBase<dim, spacedim> &fe_values,
-               const std::vector<Number> &        independent_local_dof_values,
-               const FEValuesExtractors::Scalar & variable,
-               std::vector<Tensor<2, spacedim, Number>> &us)
+  get_hessians(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+               const std::vector<Number> &independent_local_dof_values,
+               const dealii::FEValuesExtractors::Scalar &        variable,
+               std::vector<dealii::Tensor<2, spacedim, Number>> &us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;
@@ -486,17 +485,17 @@ namespace DOFUtilities
   /**
    *  Extract hessians local dofs values of a vector variable
    *  in a cell and store them in
-   *  std::vector <Tensor<3,Number > > us
+   *  std::vector <dealii::Tensor<3,Number > > us
    *  whose size is number of quadrature points in the cell.
    *
    */
   template <int dim, int spacedim, typename Number>
 
   void
-  get_hessians(const FEValuesBase<dim, spacedim> &fe_values,
-               const std::vector<Number> &        independent_local_dof_values,
-               const FEValuesExtractors::Vector & variable,
-               std::vector<Tensor<3, spacedim, Number>> &us)
+  get_hessians(const dealii::FEValuesBase<dim, spacedim> &fe_values,
+               const std::vector<Number> &independent_local_dof_values,
+               const dealii::FEValuesExtractors::Vector &        variable,
+               std::vector<dealii::Tensor<3, spacedim, Number>> &us)
 
   {
     const unsigned int dofs_per_cell = fe_values.dofs_per_cell;

--- a/include/deal2lkit/error_handler.h
+++ b/include/deal2lkit/error_handler.h
@@ -62,7 +62,6 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <string>
 #include <vector>
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -90,32 +89,33 @@ public:
 
   /** Initialize the given values for the paramter file. */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /** Parse the given parameter handler. */
   virtual void
-  parse_parameters(ParameterHandler &prm);
+  parse_parameters(dealii::ParameterHandler &prm);
 
   /** Calculate the error of the numeric solution in variuous norms. Store
       the result in the given table. */
   template <typename DH, typename VEC>
   void
-  error_from_exact(const DH &                           vspace,
-                   const VEC &                          solution,
-                   const Function<DH::space_dimension> &exact,
-                   unsigned int                         table_no = 0,
-                   double                               dt       = 0.);
+  error_from_exact(const DH &                                   vspace,
+                   const VEC &                                  solution,
+                   const dealii::Function<DH::space_dimension> &exact,
+                   unsigned int                                 table_no = 0,
+                   double                                       dt       = 0.);
 
 
   /** Same as above, with different mapping. */
   template <typename DH, typename VEC>
   void
-  error_from_exact(const Mapping<DH::dimension, DH::space_dimension> &mapping,
-                   const DH &                                         vspace,
-                   const VEC &                                        solution,
-                   const Function<DH::space_dimension> &              exact,
-                   unsigned int table_no = 0,
-                   double       dt       = 0.);
+  error_from_exact(
+    const dealii::Mapping<DH::dimension, DH::space_dimension> &mapping,
+    const DH &                                                 vspace,
+    const VEC &                                                solution,
+    const dealii::Function<DH::space_dimension> &              exact,
+    unsigned int                                               table_no = 0,
+    double                                                     dt       = 0.);
 
 
   /** Call the given custom function to compute the custom error for
@@ -164,7 +164,8 @@ public:
   /** By default output first table. The output is according to
       to the condition of ConditionalOStream &pcout */
   void
-  output_table(ConditionalOStream &pcout, const unsigned int table_no = 0);
+  output_table(dealii::ConditionalOStream &pcout,
+               const unsigned int          table_no = 0);
 
 private:
   /** Value of solution names. */
@@ -174,7 +175,7 @@ private:
   const std::string list_of_error_norms;
 
   /** Error results.*/
-  std::vector<ConvergenceTable> tables;
+  std::vector<dealii::ConvergenceTable> tables;
 
   /** Headers for tables and output. Contains the name of the solution
       components. */
@@ -290,14 +291,15 @@ ErrorHandler<ntables>::difference(const DH &    dh,
                                   double        dt)
 {
   AssertThrow(solution1.size() == solution2.size(),
-              ExcDimensionMismatch(solution1.size(), solution2.size()));
+              dealii::ExcDimensionMismatch(solution1.size(), solution2.size()));
   VECTOR solution(solution1);
   solution -= solution2;
-  error_from_exact(dh,
-                   solution,
-                   ConstantFunction<DH::space_dimension>(0, headers.size()),
-                   table_no,
-                   dt);
+  error_from_exact(
+    dh,
+    solution,
+    dealii::ConstantFunction<DH::space_dimension>(0, headers.size()),
+    table_no,
+    dt);
 }
 
 
@@ -306,41 +308,42 @@ template <int ntables>
 template <typename DH, typename VECTOR>
 void
 ErrorHandler<ntables>::error_from_exact(
-  const DH &                           dh,
-  const VECTOR &                       solution,
-  const Function<DH::space_dimension> &exact,
-  unsigned int                         table_no,
-  double                               dt)
+  const DH &                                   dh,
+  const VECTOR &                               solution,
+  const dealii::Function<DH::space_dimension> &exact,
+  unsigned int                                 table_no,
+  double                                       dt)
 {
-  error_from_exact(StaticMappingQ1<DH::dimension, DH::space_dimension>::mapping,
-                   dh,
-                   solution,
-                   exact,
-                   table_no,
-                   dt);
+  error_from_exact(
+    dealii::StaticMappingQ1<DH::dimension, DH::space_dimension>::mapping,
+    dh,
+    solution,
+    exact,
+    table_no,
+    dt);
 }
 
 template <int ntables>
 template <typename DH, typename VECTOR>
 void
 ErrorHandler<ntables>::error_from_exact(
-  const Mapping<DH::dimension, DH::space_dimension> &mapping,
-  const DH &                                         dh,
-  const VECTOR &                                     solution,
-  const Function<DH::space_dimension> &              exact,
-  unsigned int                                       table_no,
-  double                                             dt)
+  const dealii::Mapping<DH::dimension, DH::space_dimension> &mapping,
+  const DH &                                                 dh,
+  const VECTOR &                                             solution,
+  const dealii::Function<DH::space_dimension> &              exact,
+  unsigned int                                               table_no,
+  double                                                     dt)
 {
   const int dim      = DH::dimension;
   const int spacedim = DH::space_dimension;
   if (compute_error)
     {
-      AssertThrow(initialized, ExcNotInitialized());
+      AssertThrow(initialized, dealii::ExcNotInitialized());
       AssertThrow(table_no < types.size(),
-                  ExcIndexRange(table_no, 0, names.size()));
+                  dealii::ExcIndexRange(table_no, 0, names.size()));
       AssertThrow(exact.n_components == types[table_no].size(),
-                  ExcDimensionMismatch(exact.n_components,
-                                       types[table_no].size()));
+                  dealii::ExcDimensionMismatch(exact.n_components,
+                                               types[table_no].size()));
 
       std::vector<std::vector<double>> error(exact.n_components,
                                              std::vector<double>(4));
@@ -381,13 +384,13 @@ ErrorHandler<ntables>::error_from_exact(
           NormFlags norm = types[table_no][component];
 
           // Select one Component
-          ComponentSelectFunction<spacedim> select_component(
+          dealii::ComponentSelectFunction<spacedim> select_component(
             component, 1., exact.n_components);
 
-          Vector<float> difference_per_cell(
+          dealii::Vector<float> difference_per_cell(
             dh.get_triangulation().n_global_active_cells());
 
-          QGauss<dim> q_gauss((dh.get_fe().degree + 1) * 2);
+          dealii::QGauss<dim> q_gauss((dh.get_fe().degree + 1) * 2);
 
           // The add bit is set
           add_this = (norm & AddUp);
@@ -404,14 +407,15 @@ ErrorHandler<ntables>::error_from_exact(
 
           if (compute_L2)
             {
-              VectorTools::integrate_difference(mapping,
-                                                dh,
-                                                solution,
-                                                exact,
-                                                difference_per_cell,
-                                                q_gauss,
-                                                VectorTools::L2_norm,
-                                                &select_component);
+              dealii::VectorTools::integrate_difference(
+                mapping,
+                dh,
+                solution,
+                exact,
+                difference_per_cell,
+                q_gauss,
+                dealii::VectorTools::L2_norm,
+                &select_component);
             }
 
           const double L2_error = difference_per_cell.l2_norm();
@@ -419,42 +423,45 @@ ErrorHandler<ntables>::error_from_exact(
 
           if (compute_H1)
             {
-              VectorTools::integrate_difference(mapping,
-                                                dh, // dof_handler,
-                                                solution,
-                                                exact,
-                                                difference_per_cell,
-                                                q_gauss,
-                                                VectorTools::H1_norm,
-                                                &select_component);
+              dealii::VectorTools::integrate_difference(
+                mapping,
+                dh, // dof_handler,
+                solution,
+                exact,
+                difference_per_cell,
+                q_gauss,
+                dealii::VectorTools::H1_norm,
+                &select_component);
             }
           const double H1_error = difference_per_cell.l2_norm();
           difference_per_cell   = 0;
 
           if (compute_W1infty)
             {
-              VectorTools::integrate_difference(mapping,
-                                                dh, // dof_handler,
-                                                solution,
-                                                exact,
-                                                difference_per_cell,
-                                                q_gauss,
-                                                VectorTools::W1infty_norm,
-                                                &select_component);
+              dealii::VectorTools::integrate_difference(
+                mapping,
+                dh, // dof_handler,
+                solution,
+                exact,
+                difference_per_cell,
+                q_gauss,
+                dealii::VectorTools::W1infty_norm,
+                &select_component);
             }
 
           const double W1inf_error = difference_per_cell.linfty_norm();
 
           if (compute_Linfty)
             {
-              VectorTools::integrate_difference(mapping,
-                                                dh, // dof_handler,
-                                                solution,
-                                                exact,
-                                                difference_per_cell,
-                                                q_gauss,
-                                                VectorTools::Linfty_norm,
-                                                &select_component);
+              dealii::VectorTools::integrate_difference(
+                mapping,
+                dh, // dof_handler,
+                solution,
+                exact,
+                difference_per_cell,
+                q_gauss,
+                dealii::VectorTools::Linfty_norm,
+                &select_component);
             }
 
           const double Linf_error = difference_per_cell.linfty_norm();
@@ -462,7 +469,7 @@ ErrorHandler<ntables>::error_from_exact(
           if (add_this)
             {
               AssertThrow(component,
-                          ExcMessage("Cannot add on first component!"));
+                          dealii::ExcMessage("Cannot add on first component!"));
 
               error[last_non_add][0] =
                 std::max(error[last_non_add][0], Linf_error);
@@ -558,9 +565,9 @@ ErrorHandler<ntables>::custom_error(
 {
   if (compute_error)
     {
-      AssertThrow(initialized, ExcNotInitialized());
+      AssertThrow(initialized, dealii::ExcNotInitialized());
       AssertThrow(table_no < types.size(),
-                  ExcIndexRange(table_no, 0, types.size()));
+                  dealii::ExcIndexRange(table_no, 0, types.size()));
 
       const unsigned int  n_components = types.size();
       std::vector<double> c_error(types[table_no].size());
@@ -613,7 +620,7 @@ ErrorHandler<ntables>::custom_error(
           if (add_this)
             {
               AssertThrow(component,
-                          ExcMessage("Cannot add on first component!"));
+                          dealii::ExcMessage("Cannot add on first component!"));
 
               c_error[last_non_add] += Custom_error;
             }

--- a/include/deal2lkit/fe_values_cache.h
+++ b/include/deal2lkit/fe_values_cache.h
@@ -40,8 +40,8 @@ D2K_NAMESPACE_OPEN
  * FEValuesCache fev(mapping, fe, quad, flags, face_quad, face_flags);
  *
  * // A couple of extractors, to simplify things.
- * FEValuesExtractors::Vector velocity(0);
- * FEValuesExtractors::Vector pressure(dim);
+ * dealii::FEValuesExtractors::Vector velocity(0);
+ * dealii::FEValuesExtractors::Vector pressure(dim);
  *
  * for(auto cell : dh.active_cell_iterators()) {
  *   fev.reinit(cell);
@@ -54,7 +54,7 @@ D2K_NAMESPACE_OPEN
  *
  *   // get the values of the velocity and pressure
  *   // at the quadrature points
- *   std::vector<Tensor<1,dim> > &velocities
+ *   std::vector<dealii::Tensor<1,dim> > &velocities
  *      = fev.get_values("solution", "v", velocities, dummy);
  *
  *   std::vector<double> &divergences
@@ -68,13 +68,14 @@ D2K_NAMESPACE_OPEN
  * }
  * @endcode
  *
- * Internally, FEValuesCache creates unique objects of the right size and type,
- * whenever on of the get_* function is called. These objects are identified by
- * four things: the type of FEValues (either FEValues, or FEFaceValues),
- * the finite element vector identifier ("solution", in the example
- * above), the field type identifier ("v", "div_v", and "p" in the example
- * above), and the type of the dummy variable (used only to determine its type.
- * The value of the variable is ignored).
+ * Internally, FEValuesCache creates unique objects of the right size
+ * and type, whenever on of the get_* function is called. These objects are
+ * identified by four things: the type of dealii::FEValues (either
+ * dealii::FEValues, or dealii::FEFaceValues), the finite element vector
+ * identifier ("solution", in the example above), the field type identifier
+ * ("v", "div_v", and "p" in the example above), and the type of the dummy
+ * variable (used only to determine its type. The value of the variable is
+ * ignored).
  *
  * These objects are created the first time these functions are called with a
  * unique identifier, and reused by reference all subsequent times, saving you
@@ -100,12 +101,12 @@ public:
   /**
    * Explicit constructor.
    */
-  FEValuesCache(const Mapping<dim, spacedim> &      mapping,
-                const FiniteElement<dim, spacedim> &fe,
-                const Quadrature<dim> &             quadrature,
-                const UpdateFlags &                 update_flags,
-                const Quadrature<dim - 1> &         face_quadrature,
-                const UpdateFlags &                 face_update_flags)
+  FEValuesCache(const dealii::Mapping<dim, spacedim> &      mapping,
+                const dealii::FiniteElement<dim, spacedim> &fe,
+                const dealii::Quadrature<dim> &             quadrature,
+                const dealii::UpdateFlags &                 update_flags,
+                const dealii::Quadrature<dim - 1> &         face_quadrature,
+                const dealii::UpdateFlags &                 face_update_flags)
     : fe_values(mapping, fe, quadrature, update_flags)
     , fe_face_values(mapping, fe, face_quadrature, face_update_flags)
     , fe_subface_values(mapping, fe, face_quadrature, face_update_flags)
@@ -134,47 +135,50 @@ public:
 
 
   /**
-   * Initialize the internal FEValues to use the given @p cell.
+   * Initialize the internal dealii::FEValues to use the given @p cell.
    */
   void
-  reinit(const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell)
+  reinit(const typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
+           &cell)
   {
     fe_values.reinit(cell);
     cell->get_dof_indices(local_dof_indices);
-    cache.template add_ref<FEValuesBase<dim, spacedim>>(fe_values,
-                                                        "FEValuesBase");
-  };
+    cache.template add_ref<dealii::FEValuesBase<dim, spacedim>>(fe_values,
+                                                                "FEValuesBase");
+  }
 
 
   /**
-   * Initialize the internal FEFaceValues to use the given @p face_no on the given
+   * Initialize the internal dealii::FEFaceValues to use the given @p face_no on the given
    * @p cell.
    */
   void
-  reinit(const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+  reinit(const typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
+           &                cell,
          const unsigned int face_no)
   {
     fe_face_values.reinit(cell, face_no);
     cell->get_dof_indices(local_dof_indices);
-    cache.template add_ref<FEValuesBase<dim, spacedim>>(fe_face_values,
-                                                        "FEValuesBase");
-  };
+    cache.template add_ref<dealii::FEValuesBase<dim, spacedim>>(fe_face_values,
+                                                                "FEValuesBase");
+  }
 
 
   /**
-   * Initialize the internal FESubFaceValues to use the given @p subface_no, on @p face_no,
+   * Initialize the internal dealii::FESubfaceValues to use the given @p subface_no, on @p face_no,
    * on the given @p cell.
    */
   void
-  reinit(const typename DoFHandler<dim, spacedim>::active_cell_iterator &cell,
+  reinit(const typename dealii::DoFHandler<dim, spacedim>::active_cell_iterator
+           &                cell,
          const unsigned int face_no,
          const unsigned int subface_no)
   {
     fe_subface_values.reinit(cell, face_no, subface_no);
     cell->get_dof_indices(local_dof_indices);
-    cache.template add_ref<FEValuesBase<dim, spacedim>>(fe_subface_values,
-                                                        "FEValuesBase");
-  };
+    cache.template add_ref<dealii::FEValuesBase<dim, spacedim>>(
+      fe_subface_values, "FEValuesBase");
+  }
 
   /**
    * @brief Get the reference to @p cache.
@@ -185,23 +189,24 @@ public:
   get_cache()
   {
     return cache;
-  };
+  }
 
   /**
-   * Get the currently initialized FEValues.
+   * Get the currently initialized dealii::FEValues.
    *
-   * This function will return the internal FEValues if the reinit(cell)
+   * This function will return the internal dealii::FEValues if the reinit(cell)
    * function was called last. If the reinit(cell, face_no) function was called,
-   * then this function returns the internal FEFaceValues.
+   * then this function returns the internal dealii::FEFaceValues.
    */
-  const FEValuesBase<dim, spacedim> &
+  const dealii::FEValuesBase<dim, spacedim> &
   get_current_fe_values()
   {
     Assert(cache.have("FEValuesBase"),
-           ExcMessage("You have to initialize the cache using one of the "
-                      "reinit function first!"));
-    FEValuesBase<dim, spacedim> &fev =
-      cache.template get<FEValuesBase<dim, spacedim>>("FEValuesBase");
+           dealii::ExcMessage(
+             "You have to initialize the cache using one of the "
+             "reinit function first!"));
+    dealii::FEValuesBase<dim, spacedim> &fev =
+      cache.template get<dealii::FEValuesBase<dim, spacedim>>("FEValuesBase");
     return fev;
   }
 
@@ -217,7 +222,7 @@ public:
 
     Assert(
       cache.have(dofs_name),
-      ExcMessage(
+      dealii::ExcMessage(
         "You did not call cache_local_solution_vector with the right types!"));
 
     return cache.template get<std::vector<Number>>(dofs_name);
@@ -225,9 +230,9 @@ public:
 
 
   /**
-   * Return the quadrature points of the internal FEValues object.
+   * Return the quadrature points of the internal dealii::FEValues object.
    */
-  const std::vector<Point<spacedim>> &
+  const std::vector<dealii::Point<spacedim>> &
   get_quadrature_points()
   {
     return get_current_fe_values().get_quadrature_points();
@@ -235,7 +240,7 @@ public:
 
 
   /**
-   * Return the JxW values of the internal FEValues object.
+   * Return the JxW values of the internal dealii::FEValues object.
    */
   const std::vector<double> &
   get_JxW_values()
@@ -308,13 +313,14 @@ public:
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points   = fev.n_quadrature_points;
     const unsigned int n_components = fev.get_fe().n_components();
 
     std::string name = prefix + "_all_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     if (!cache.have(name))
       {
@@ -340,20 +346,21 @@ public:
    */
   template <typename Number>
   const std::vector<Number> &
-  get_values(const std::string &               prefix,
-             const std::string &               additional_prefix,
-             const FEValuesExtractors::Scalar &variable,
-             const Number                      dummy)
+  get_values(const std::string &                       prefix,
+             const std::string &                       additional_prefix,
+             const dealii::FEValuesExtractors::Scalar &variable,
+             const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_scalar_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
     typedef typename std::vector<Number> RetType;
@@ -377,25 +384,26 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<1, spacedim, Number>> &
-  get_values(const std::string &               prefix,
-             const std::string &               additional_prefix,
-             const FEValuesExtractors::Vector &vector_variable,
-             const Number                      dummy)
+  const std::vector<dealii::Tensor<1, spacedim, Number>> &
+  get_values(const std::string &                       prefix,
+             const std::string &                       additional_prefix,
+             const dealii::FEValuesExtractors::Vector &vector_variable,
+             const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_vector_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
 
     // Now build the return type
-    typedef typename std::vector<Tensor<1, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<1, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -416,20 +424,21 @@ public:
    */
   template <typename Number>
   const std::vector<Number> &
-  get_divergences(const std::string &               prefix,
-                  const std::string &               additional_prefix,
-                  const FEValuesExtractors::Vector &vector_variable,
-                  const Number                      dummy)
+  get_divergences(const std::string &                       prefix,
+                  const std::string &                       additional_prefix,
+                  const dealii::FEValuesExtractors::Vector &vector_variable,
+                  const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_div_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
 
     // Now build the return type
@@ -456,24 +465,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<1, spacedim, Number>> &
-  get_gradients(const std::string &               prefix,
-                const std::string &               additional_prefix,
-                const FEValuesExtractors::Scalar &variable,
-                const Number                      dummy)
+  const std::vector<dealii::Tensor<1, spacedim, Number>> &
+  get_gradients(const std::string &                       prefix,
+                const std::string &                       additional_prefix,
+                const dealii::FEValuesExtractors::Scalar &variable,
+                const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_grad_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<1, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<1, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -493,24 +503,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<2, spacedim, Number>> &
-  get_gradients(const std::string &               prefix,
-                const std::string &               additional_prefix,
-                const FEValuesExtractors::Vector &variable,
-                const Number                      dummy)
+  const std::vector<dealii::Tensor<2, spacedim, Number>> &
+  get_gradients(const std::string &                       prefix,
+                const std::string &                       additional_prefix,
+                const dealii::FEValuesExtractors::Vector &variable,
+                const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_grad2_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<2, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<2, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -528,26 +539,27 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<1, (spacedim > 2 ? spacedim : 1), Number>> &
-  get_curls(const std::string &               prefix,
-            const std::string &               additional_prefix,
-            const FEValuesExtractors::Vector &variable,
-            const Number                      dummy)
+  const std::vector<dealii::Tensor<1, (spacedim > 2 ? spacedim : 1), Number>> &
+  get_curls(const std::string &                       prefix,
+            const std::string &                       additional_prefix,
+            const dealii::FEValuesExtractors::Vector &variable,
+            const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_curl_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
-    typedef
-      typename std::vector<Tensor<1, (spacedim > 2 ? spacedim : 1), Number>>
-        RetType;
+    typedef typename std::vector<
+      dealii::Tensor<1, (spacedim > 2 ? spacedim : 1), Number>>
+      RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -566,21 +578,21 @@ public:
    */
   template <typename Number>
   const std::vector<Number> &
-  get_laplacians(const std::string &               prefix,
-                 const std::string &               additional_prefix,
-                 const FEValuesExtractors::Scalar &variable,
-                 const Number                      dummy)
+  get_laplacians(const std::string &                       prefix,
+                 const std::string &                       additional_prefix,
+                 const dealii::FEValuesExtractors::Scalar &variable,
+                 const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
-    std::string name = prefix + "_" + additional_prefix +
-                       "_laplacian_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+    std::string name =
+      prefix + "_" + additional_prefix + "_laplacian_values_q" +
+      dealii::Utilities::int_to_string(n_q_points) + "_" + type(dummy);
 
     // Now build the return type
     typedef typename std::vector<Number> RetType;
@@ -603,25 +615,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<1, spacedim, Number>> &
-  get_laplacians(const std::string &               prefix,
-                 const std::string &               additional_prefix,
-                 const FEValuesExtractors::Vector &variable,
-                 const Number                      dummy)
+  const std::vector<dealii::Tensor<1, spacedim, Number>> &
+  get_laplacians(const std::string &                       prefix,
+                 const std::string &                       additional_prefix,
+                 const dealii::FEValuesExtractors::Vector &variable,
+                 const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
-    std::string name = prefix + "_" + additional_prefix +
-                       "_laplacian2_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+    std::string name =
+      prefix + "_" + additional_prefix + "_laplacian2_values_q" +
+      dealii::Utilities::int_to_string(n_q_points) + "_" + type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<1, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<1, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -639,24 +651,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<2, spacedim, Number>> &
-  get_deformation_gradients(const std::string &               prefix,
-                            const std::string &               additional_prefix,
-                            const FEValuesExtractors::Vector &variable,
-                            const Number                      dummy)
+  const std::vector<dealii::Tensor<2, spacedim, Number>> &
+  get_deformation_gradients(const std::string &prefix,
+                            const std::string &additional_prefix,
+                            const dealii::FEValuesExtractors::Vector &variable,
+                            const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_F_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<2, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<2, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -679,24 +692,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<2, spacedim, Number>> &
-  get_symmetric_gradients(const std::string &               prefix,
-                          const std::string &               additional_prefix,
-                          const FEValuesExtractors::Vector &variable,
-                          const Number                      dummy)
+  const std::vector<dealii::Tensor<2, spacedim, Number>> &
+  get_symmetric_gradients(const std::string &prefix,
+                          const std::string &additional_prefix,
+                          const dealii::FEValuesExtractors::Vector &variable,
+                          const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_sym_grad_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<2, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<2, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -717,24 +731,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<2, spacedim, Number>> &
-  get_hessians(const std::string &               prefix,
-               const std::string &               additional_prefix,
-               const FEValuesExtractors::Scalar &variable,
-               const Number                      dummy)
+  const std::vector<dealii::Tensor<2, spacedim, Number>> &
+  get_hessians(const std::string &                       prefix,
+               const std::string &                       additional_prefix,
+               const dealii::FEValuesExtractors::Scalar &variable,
+               const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
     std::string name = prefix + "_" + additional_prefix + "_hessians_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+                       dealii::Utilities::int_to_string(n_q_points) + "_" +
+                       type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<2, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<2, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -752,25 +767,25 @@ public:
    * and with the same dummy type you use here.
    */
   template <typename Number>
-  const std::vector<Tensor<3, spacedim, Number>> &
-  get_hessians(const std::string &               prefix,
-               const std::string &               additional_prefix,
-               const FEValuesExtractors::Vector &variable,
-               const Number                      dummy)
+  const std::vector<dealii::Tensor<3, spacedim, Number>> &
+  get_hessians(const std::string &                       prefix,
+               const std::string &                       additional_prefix,
+               const dealii::FEValuesExtractors::Vector &variable,
+               const Number                              dummy)
   {
     const std::vector<Number> &independent_local_dofs =
       get_current_independent_local_dofs(prefix, dummy);
 
-    const FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
+    const dealii::FEValuesBase<dim, spacedim> &fev = get_current_fe_values();
 
     const unsigned int n_q_points = fev.n_quadrature_points;
 
-    std::string name = prefix + "_" + additional_prefix +
-                       "_hessians2_values_q" +
-                       Utilities::int_to_string(n_q_points) + "_" + type(dummy);
+    std::string name =
+      prefix + "_" + additional_prefix + "_hessians2_values_q" +
+      dealii::Utilities::int_to_string(n_q_points) + "_" + type(dummy);
 
     // Now build the return type
-    typedef typename std::vector<Tensor<3, spacedim, Number>> RetType;
+    typedef typename std::vector<dealii::Tensor<3, spacedim, Number>> RetType;
 
     if (!cache.have(name))
       cache.add_copy(RetType(n_q_points), name);
@@ -781,11 +796,11 @@ public:
   }
 
 private:
-  AnyData                              cache;
-  FEValues<dim, spacedim>              fe_values;
-  FEFaceValues<dim, spacedim>          fe_face_values;
-  FESubfaceValues<dim, spacedim>       fe_subface_values;
-  std::vector<types::global_dof_index> local_dof_indices;
+  AnyData                                      cache;
+  dealii::FEValues<dim, spacedim>              fe_values;
+  dealii::FEFaceValues<dim, spacedim>          fe_face_values;
+  dealii::FESubfaceValues<dim, spacedim>       fe_subface_values;
+  std::vector<dealii::types::global_dof_index> local_dof_indices;
 };
 
 D2K_NAMESPACE_CLOSE

--- a/include/deal2lkit/ida_interface.h
+++ b/include/deal2lkit/ida_interface.h
@@ -129,7 +129,7 @@ D2K_NAMESPACE_OPEN
  * its problem class from the SundialsInterface class, and
  * implement all pure virtual methods.
  */
-template <typename VEC = Vector<double>>
+template <typename VEC = dealii::Vector<double>>
 class IDAInterface : public ParameterAcceptor
 {
 public:
@@ -151,7 +151,7 @@ public:
 
   /** Declare parameters for this class to function properly. */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /** Evolve. This function returns the final number of steps. */
   unsigned int
@@ -307,7 +307,7 @@ private:
 #  endif
 
   /** Output stream */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   unsigned int system_size;
 

--- a/include/deal2lkit/imex_stepper.h
+++ b/include/deal2lkit/imex_stepper.h
@@ -53,7 +53,7 @@ D2K_NAMESPACE_OPEN
  *  - vector_norm (if kinsol is not used).
  *
  */
-template <typename VEC = Vector<double>>
+template <typename VEC = dealii::Vector<double>>
 class IMEXStepper : public ParameterAcceptor
 {
 public:
@@ -75,7 +75,7 @@ public:
 
   /** Declare parameters for this class to function properly. */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /** Evolve. This function returns the final number of steps. */
   unsigned int
@@ -163,7 +163,7 @@ private:
   bool use_kinsol;
 
   /** Output stream */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   /** print useful informations */
   bool verbose;

--- a/include/deal2lkit/kinsol_interface.h
+++ b/include/deal2lkit/kinsol_interface.h
@@ -38,7 +38,6 @@
 
 #  include <kinsol/kinsol_impl.h>
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -51,7 +50,7 @@ D2K_NAMESPACE_OPEN
  * This is a general-purpose nonlinear system solver based on Newton-Krylov
  * solver technology. Developed with KINSOL v.2.8.0.
  */
-template <typename VEC = Vector<double>>
+template <typename VEC = dealii::Vector<double>>
 class KINSOLInterface : public ParameterAcceptor
 {
 public:
@@ -90,7 +89,7 @@ public:
    * Declare parameters for this class to function properly.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Initializes the solver with the initial guess and the residual function.
@@ -249,7 +248,7 @@ private:
   /**
    * Output stream
    */
-  ConditionalOStream pcout;
+  dealii::ConditionalOStream pcout;
 
   /**
    * Kinsol memory object.

--- a/include/deal2lkit/parameter_acceptor.h
+++ b/include/deal2lkit/parameter_acceptor.h
@@ -28,10 +28,6 @@
 
 #include <typeinfo>
 
-
-
-using namespace dealii;
-
 D2K_NAMESPACE_OPEN
 
 /**
@@ -380,7 +376,7 @@ D2K_NAMESPACE_OPEN
  * sensible on the first run, without having to change any parameter
  * file.
  */
-class ParameterAcceptor : public Subscriptor
+class ParameterAcceptor : public dealii::Subscriptor
 {
 public:
   /**
@@ -420,7 +416,7 @@ public:
    * all parameters that were added using add_parameter().
    */
   virtual void
-  parse_parameters(ParameterHandler &prm);
+  parse_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Parse parameter call back. This function is called at the end
@@ -454,7 +450,8 @@ public:
    * and parsing of parameters into two functions.
    */
   virtual void
-  declare_parameters(ParameterHandler &){};
+  declare_parameters(dealii::ParameterHandler &)
+  {}
 
 
   /**
@@ -463,7 +460,7 @@ public:
    * and parses all parameters that were added using add_parameter().
    */
   static void
-  parse_all_parameters(ParameterHandler &prm = ParameterAcceptor::prm);
+  parse_all_parameters(dealii::ParameterHandler &prm = ParameterAcceptor::prm);
 
 
   /**
@@ -480,7 +477,8 @@ public:
    * parameters that were added using add_parameter().
    */
   static void
-  declare_all_parameters(ParameterHandler &prm = ParameterAcceptor::prm);
+  declare_all_parameters(
+    dealii::ParameterHandler &prm = ParameterAcceptor::prm);
 
 
   /**
@@ -506,22 +504,24 @@ public:
    */
   template <class T>
   void
-  add_parameter(ParameterHandler &           prm,
-                T *                          parameter,
-                const std::string &          entry,
-                const std::string &          default_value,
-                const Patterns::PatternBase &pattern = Patterns::Anything(),
-                const std::string &          documentation = std::string())
+  add_parameter(
+    dealii::ParameterHandler &           prm,
+    T *                                  parameter,
+    const std::string &                  entry,
+    const std::string &                  default_value,
+    const dealii::Patterns::PatternBase &pattern = dealii::Patterns::Anything(),
+    const std::string &                  documentation = std::string())
   {
     AssertThrow(std::is_const<T>::value == false,
-                ExcMessage("You tried to add a parameter using a const "
-                           "variable. This is not allowed, since these "
-                           "variables will be filled later on when "
-                           "parsing the parameter."));
+                dealii::ExcMessage("You tried to add a parameter using a const "
+                                   "variable. This is not allowed, since these "
+                                   "variables will be filled later on when "
+                                   "parsing the parameter."));
 
     prm.declare_entry(entry, default_value, pattern, documentation);
     parameters[entry] = boost::any(parameter);
-    patterns[entry]   = std::unique_ptr<Patterns::PatternBase>(pattern.clone());
+    patterns[entry] =
+      std::unique_ptr<dealii::Patterns::PatternBase>(pattern.clone());
   }
 
 
@@ -543,23 +543,24 @@ public:
    */
   template <class T>
   void
-  add_parameter(T &                          parameter,
-                const std::string &          entry,
-                const std::string &          documentation = std::string(),
-                const Patterns::PatternBase &pattern       = *to_pattern(T()),
-                ParameterHandler &           prm = ParameterAcceptor::prm)
+  add_parameter(T &                parameter,
+                const std::string &entry,
+                const std::string &documentation             = std::string(),
+                const dealii::Patterns::PatternBase &pattern = *to_pattern(T()),
+                dealii::ParameterHandler &prm = ParameterAcceptor::prm)
   {
     AssertThrow(std::is_const<T>::value == false,
-                ExcMessage("You tried to add a parameter using a const "
-                           "variable. This is not allowed, since these "
-                           "variables will be filled later on when "
-                           "parsing the parameter."));
+                dealii::ExcMessage("You tried to add a parameter using a const "
+                                   "variable. This is not allowed, since these "
+                                   "variables will be filled later on when "
+                                   "parsing the parameter."));
 
     enter_my_subsection(prm);
     prm.declare_entry(entry, to_string(parameter), pattern, documentation);
     leave_my_subsection(prm);
     parameters[entry] = boost::any(&parameter);
-    patterns[entry]   = std::unique_ptr<Patterns::PatternBase>(pattern.clone());
+    patterns[entry] =
+      std::unique_ptr<dealii::Patterns::PatternBase>(pattern.clone());
   }
 
   /**
@@ -567,21 +568,21 @@ public:
    * This function should be called when prm is in its root subsection.
    */
   void
-  enter_my_subsection(ParameterHandler &prm);
+  enter_my_subsection(dealii::ParameterHandler &prm);
 
   /**
    * This function undoes what the enter_my_subsection() function did. It only
    * makes sense if enter_my_subsection() is called before this one.
    */
   void
-  leave_my_subsection(ParameterHandler &prm);
+  leave_my_subsection(dealii::ParameterHandler &prm);
 
   /**
    * Given a class T, construct its default pattern to be used when declaring
    * parameters.
    */
   template <class T>
-  static std::shared_ptr<Patterns::PatternBase>
+  static std::shared_ptr<dealii::Patterns::PatternBase>
   to_pattern(const T &);
 
   /**
@@ -601,14 +602,14 @@ public:
   /**
    * Static parameter. This is used if the user does not provide one.
    */
-  static ParameterHandler prm;
+  static dealii::ParameterHandler prm;
 
 private:
   /**
    * A list containing all constructed classes of type
    * ParameterAcceptor.
    */
-  static std::vector<SmartPointer<ParameterAcceptor>> class_list;
+  static std::vector<dealii::SmartPointer<ParameterAcceptor>> class_list;
 
   /** The index of this specific class within the class list. */
   const unsigned int acceptor_id;
@@ -623,7 +624,7 @@ private:
    * A map of patterns that are initialized in this class with the
    * functions add_parameters.
    */
-  mutable std::map<std::string, std::unique_ptr<Patterns::PatternBase>>
+  mutable std::map<std::string, std::unique_ptr<dealii::Patterns::PatternBase>>
     patterns;
 
 

--- a/include/deal2lkit/parsed_data_out.h
+++ b/include/deal2lkit/parsed_data_out.h
@@ -55,7 +55,7 @@ public:
 
   /** Initialize the given values for the paramter file. */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /** Prepare names for output directories. */
   virtual void
@@ -66,8 +66,8 @@ public:
       combination of the @p base_name, the optional @p suffix,
       eventually a processor number and the output suffix.  */
   void
-  prepare_data_output(const DoFHandler<dim, spacedim> &dh,
-                      const std::string &              suffix = "");
+  prepare_data_output(const dealii::DoFHandler<dim, spacedim> &dh,
+                      const std::string &                      suffix = "");
 
   /** Add the given vector to the output file. Prior to calling this
       method, you have to call the prepare_data_output method. The
@@ -84,8 +84,8 @@ public:
    */
   template <typename VECTOR>
   void
-  add_data_vector(const VECTOR &                     data_vector,
-                  const DataPostprocessor<spacedim> &postproc);
+  add_data_vector(const VECTOR &                             data_vector,
+                  const dealii::DataPostprocessor<spacedim> &postproc);
 
 
   /** Actually write the file. Once the data_out has been prepared,
@@ -97,8 +97,8 @@ public:
       (ex. "parameter.prm time.dat") and copies these files
       in the @p incremental_run_prefix of the costructor function.*/
   void
-  write_data_and_clear(const Mapping<dim, spacedim> &mapping =
-                         StaticMappingQ1<dim, spacedim>::mapping);
+  write_data_and_clear(const dealii::Mapping<dim, spacedim> &mapping =
+                         dealii::StaticMappingQ1<dim, spacedim>::mapping);
 
 private:
   /** Initialization flag.*/
@@ -153,7 +153,7 @@ private:
   std::ofstream output_file;
 
   /** Outputs only the data that refers to this process. */
-  shared_ptr<DataOut<dim, DoFHandler<dim, spacedim>>> data_out;
+  shared_ptr<dealii::DataOut<dim, dealii::DoFHandler<dim, spacedim>>> data_out;
 };
 
 
@@ -167,9 +167,9 @@ void
 ParsedDataOut<dim, spacedim>::add_data_vector(const VECTOR &     data_vector,
                                               const std::string &desc)
 {
-  AssertThrow(initialized, ExcNotInitialized());
-  deallog.push("AddingData");
-  std::vector<std::string> dd = Utilities::split_string_list(desc);
+  AssertThrow(initialized, dealii::ExcNotInitialized());
+  dealii::deallog.push("AddingData");
+  std::vector<std::string> dd = dealii::Utilities::split_string_list(desc);
   if (data_out->default_suffix() != "")
     {
       if (dd.size() == 1)
@@ -187,28 +187,31 @@ ParsedDataOut<dim, spacedim>::add_data_vector(const VECTOR &     data_vector,
           std::vector<int>::iterator iit = occurrances.begin();
           sit                            = dd.begin();
 
-          std::vector<DataComponentInterpretation::DataComponentInterpretation>
+          std::vector<
+            dealii::DataComponentInterpretation::DataComponentInterpretation>
             data_component_interpretation;
 
           for (; iit != occurrances.end(); ++iit, ++sit)
             {
               if (*iit > 1)
                 data_component_interpretation.push_back(
-                  DataComponentInterpretation::component_is_part_of_vector);
+                  dealii::DataComponentInterpretation::
+                    component_is_part_of_vector);
               else
                 data_component_interpretation.push_back(
-                  DataComponentInterpretation::component_is_scalar);
+                  dealii::DataComponentInterpretation::component_is_scalar);
             }
 
           data_out->add_data_vector(
             data_vector,
             dd,
-            DataOut<dim, DoFHandler<dim, spacedim>>::type_dof_data,
+            dealii::DataOut<dim,
+                            dealii::DoFHandler<dim, spacedim>>::type_dof_data,
             data_component_interpretation);
         }
-      deallog << "Added data: " << desc << std::endl;
+      dealii::deallog << "Added data: " << desc << std::endl;
     }
-  deallog.pop();
+  dealii::deallog.pop();
 }
 
 
@@ -216,10 +219,10 @@ template <int dim, int spacedim>
 template <typename VECTOR>
 void
 ParsedDataOut<dim, spacedim>::add_data_vector(
-  const VECTOR &                     data_vector,
-  const DataPostprocessor<spacedim> &postproc)
+  const VECTOR &                             data_vector,
+  const dealii::DataPostprocessor<spacedim> &postproc)
 {
-  AssertThrow(initialized, ExcNotInitialized());
+  AssertThrow(initialized, dealii::ExcNotInitialized());
   data_out->add_data_vector(data_vector, postproc);
 }
 

--- a/include/deal2lkit/parsed_dirichlet_bcs.h
+++ b/include/deal2lkit/parsed_dirichlet_bcs.h
@@ -28,7 +28,6 @@
 #include <deal2lkit/parameter_acceptor.h>
 #include <deal2lkit/parsed_mapped_functions.h>
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -129,7 +128,7 @@ public:
    * these method calls the method of the Parent class
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * these method calls the method of the Parent class
@@ -144,19 +143,9 @@ public:
    * deal.II library
    */
   void
-  interpolate_boundary_values(const DoFHandler<dim, spacedim> &dof_handler,
-                              ConstraintMatrix &constraints) const;
-
-  /**
-   * This function must be called in order to apply the boundary conditions
-   * to the ConstraintMatrix.
-   * It relies on the VectorTools::interpolate_boundary_values functions of the
-   * deal.II library
-   */
-  void
-  interpolate_boundary_values(const Mapping<dim, spacedim> &   mapping,
-                              const DoFHandler<dim, spacedim> &dof_handler,
-                              ConstraintMatrix &constraints) const;
+  interpolate_boundary_values(
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    dealii::ConstraintMatrix &               constraints) const;
 
   /**
    * This function must be called in order to apply the boundary conditions
@@ -166,8 +155,9 @@ public:
    */
   void
   interpolate_boundary_values(
-    const DoFHandler<dim, spacedim> &          dof_handler,
-    std::map<types::global_dof_index, double> &d_dofs) const;
+    const dealii::Mapping<dim, spacedim> &   mapping,
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    dealii::ConstraintMatrix &               constraints) const;
 
   /**
    * This function must be called in order to apply the boundary conditions
@@ -177,9 +167,20 @@ public:
    */
   void
   interpolate_boundary_values(
-    const Mapping<dim, spacedim> &             mapping,
-    const DoFHandler<dim, spacedim> &          dof_handler,
-    std::map<types::global_dof_index, double> &d_dofs) const;
+    const dealii::DoFHandler<dim, spacedim> &          dof_handler,
+    std::map<dealii::types::global_dof_index, double> &d_dofs) const;
+
+  /**
+   * This function must be called in order to apply the boundary conditions
+   * to the ConstraintMatrix.
+   * It relies on the VectorTools::interpolate_boundary_values functions of the
+   * deal.II library
+   */
+  void
+  interpolate_boundary_values(
+    const dealii::Mapping<dim, spacedim> &             mapping,
+    const dealii::DoFHandler<dim, spacedim> &          dof_handler,
+    std::map<dealii::types::global_dof_index, double> &d_dofs) const;
 
   /**
    * This function must be called in order to apply the boundary conditions
@@ -188,9 +189,9 @@ public:
    * deal.II library
    */
   void
-  project_boundary_values(const DoFHandler<dim, spacedim> &dof_handler,
-                          const Quadrature<dim - 1> &      quadrature,
-                          ConstraintMatrix &               constraints) const;
+  project_boundary_values(const dealii::DoFHandler<dim, spacedim> &dof_handler,
+                          const dealii::Quadrature<dim - 1> &      quadrature,
+                          dealii::ConstraintMatrix &constraints) const;
 
   /**
    * This function must be called in order to apply the boundary conditions
@@ -199,10 +200,10 @@ public:
    * deal.II library
    */
   void
-  project_boundary_values(const Mapping<dim, spacedim> &   mapping,
-                          const DoFHandler<dim, spacedim> &dof_handler,
-                          const Quadrature<dim - 1> &      quadrature,
-                          ConstraintMatrix &               constraints) const;
+  project_boundary_values(const dealii::Mapping<dim, spacedim> &   mapping,
+                          const dealii::DoFHandler<dim, spacedim> &dof_handler,
+                          const dealii::Quadrature<dim - 1> &      quadrature,
+                          dealii::ConstraintMatrix &constraints) const;
 
   /**
    * This function must be called in order to apply the boundary conditions
@@ -212,9 +213,9 @@ public:
    */
   void
   project_boundary_values(
-    const DoFHandler<dim, spacedim> &          dof_handler,
-    const Quadrature<dim - 1> &                quadrature,
-    std::map<types::global_dof_index, double> &projected_bv) const;
+    const dealii::DoFHandler<dim, spacedim> &          dof_handler,
+    const dealii::Quadrature<dim - 1> &                quadrature,
+    std::map<dealii::types::global_dof_index, double> &projected_bv) const;
 
   /**
    * This function must be called in order to apply the boundary conditions
@@ -224,10 +225,10 @@ public:
    */
   void
   project_boundary_values(
-    const Mapping<dim, spacedim> &             mapping,
-    const DoFHandler<dim, spacedim> &          dof_handler,
-    const Quadrature<dim - 1> &                quadrature,
-    std::map<types::global_dof_index, double> &projected_bv) const;
+    const dealii::Mapping<dim, spacedim> &             mapping,
+    const dealii::DoFHandler<dim, spacedim> &          dof_handler,
+    const dealii::Quadrature<dim - 1> &                quadrature,
+    std::map<dealii::types::global_dof_index, double> &projected_bv) const;
 
 
   /**
@@ -242,8 +243,8 @@ public:
    */
   void
   compute_no_normal_flux_constraints(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    ConstraintMatrix &               constraints) const;
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    dealii::ConstraintMatrix &               constraints) const;
   /**
    * This function must be called in order to apply the homogeneous Dirichlet
    * boundary conditions to the normal components of the variables specified.
@@ -256,9 +257,9 @@ public:
    */
   void
   compute_no_normal_flux_constraints(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    const Mapping<dim, spacedim> &   mapping,
-    ConstraintMatrix &               constraints) const;
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    const dealii::Mapping<dim, spacedim> &   mapping,
+    dealii::ConstraintMatrix &               constraints) const;
   /**
    * This function must be called in order to apply the Dirichlet
    * boundary conditions to the normal components of the variables specified.
@@ -274,8 +275,8 @@ public:
    */
   void
   compute_nonzero_normal_flux_constraints(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    ConstraintMatrix &               constraints) const;
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    dealii::ConstraintMatrix &               constraints) const;
 
   /**
    * This function must be called in order to apply the Dirichlet
@@ -292,9 +293,9 @@ public:
    */
   void
   compute_nonzero_normal_flux_constraints(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    const Mapping<dim, spacedim> &   mapping,
-    ConstraintMatrix &               constraints) const;
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    const dealii::Mapping<dim, spacedim> &   mapping,
+    dealii::ConstraintMatrix &               constraints) const;
 
 private:
   /**

--- a/include/deal2lkit/parsed_finite_element.h
+++ b/include/deal2lkit/parsed_finite_element.h
@@ -26,7 +26,6 @@
 #include <deal2lkit/parameter_acceptor.h>
 #include <deal2lkit/utilities.h>
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -130,7 +129,7 @@ public:
    * 1=DoFTools::always, 2=DoFTools::nonzero.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Return a shared pointer to a newly created Finite Element. It
@@ -139,7 +138,7 @@ public:
    * different from the number of components given at construction
    * time.
    */
-  std::unique_ptr<FiniteElement<dim, spacedim>>
+  std::unique_ptr<dealii::FiniteElement<dim, spacedim>>
   operator()() const;
 
   /**

--- a/include/deal2lkit/parsed_function.h
+++ b/include/deal2lkit/parsed_function.h
@@ -21,7 +21,6 @@
 #include <deal2lkit/config.h>
 #include <deal2lkit/parameter_acceptor.h>
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -32,7 +31,7 @@ D2K_NAMESPACE_OPEN
  */
 template <int dim>
 class ParsedFunction : public ParameterAcceptor,
-                       public Functions::ParsedFunction<dim>
+                       public dealii::Functions::ParsedFunction<dim>
 {
 public:
   /**
@@ -57,13 +56,13 @@ public:
    * Calls the underlying function of ParsedFunction.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Calls the underlying function of ParsedFunction.
    */
   virtual void
-  parse_parameters(ParameterHandler &prm);
+  parse_parameters(dealii::ParameterHandler &prm);
 
 
 private:

--- a/include/deal2lkit/parsed_grid_generator.h
+++ b/include/deal2lkit/parsed_grid_generator.h
@@ -30,7 +30,6 @@
 #include <deal2lkit/parameter_acceptor.h>
 #include <deal2lkit/utilities.h>
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -196,7 +195,7 @@ public:
    * Declare all parameters of this class.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Return a pointer to a newly created serial Triangulation. It will
@@ -204,7 +203,7 @@ public:
    * is the user's responsability to destroy the created grid once it
    * is no longer needed.
    */
-  Triangulation<dim, spacedim> *
+  dealii::Triangulation<dim, spacedim> *
   serial();
 
   /**
@@ -346,7 +345,7 @@ public:
    *   - *Vector of dim int*: number of holes on each direction"
    */
   void
-  create(Triangulation<dim, spacedim> &tria);
+  create(dealii::Triangulation<dim, spacedim> &tria);
 
 #ifdef DEAL_II_WITH_MPI
 #  ifdef DEAL_II_WITH_P4EST
@@ -356,7 +355,7 @@ public:
    * occured. It is the user's responsability to destroy the created
    * grid once it is no longer needed.
    */
-  parallel::distributed::Triangulation<dim, spacedim> *
+  dealii::parallel::distributed::Triangulation<dim, spacedim> *
   distributed(MPI_Comm mpi_communicator);
 #  endif
 #endif
@@ -372,15 +371,15 @@ public:
    * GridOut method according to the extension of the file name.
    */
   void
-  write(const Triangulation<dim, spacedim> &tria,
-        const std::string &                 filename = "") const;
+  write(const dealii::Triangulation<dim, spacedim> &tria,
+        const std::string &                         filename = "") const;
 
 private:
   /**
    * Mesh smoothing. Parse the type of MeshSmoothing for the
    * generated Triangulation.
    */
-  typename Triangulation<dim, spacedim>::MeshSmoothing
+  typename dealii::Triangulation<dim, spacedim>::MeshSmoothing
   get_smoothing();
 
   /**
@@ -461,7 +460,8 @@ private:
   /**
    * A map of Manifold associated to the given manifold_ids.
    */
-  std::map<types::manifold_id, shared_ptr<Manifold<dim, spacedim>>>
+  std::map<dealii::types::manifold_id,
+           shared_ptr<dealii::Manifold<dim, spacedim>>>
     manifold_descriptors;
 
   /**
@@ -482,12 +482,12 @@ private:
   /**
    * Optional Point argument. First Option.
    */
-  Point<spacedim> point_option_one;
+  dealii::Point<spacedim> point_option_one;
 
   /**
    * Optional Point argument. Second Option.
    */
-  Point<spacedim> point_option_two;
+  dealii::Point<spacedim> point_option_two;
 
   /**
    * Optional int argument. First Option.

--- a/include/deal2lkit/parsed_grid_refinement.h
+++ b/include/deal2lkit/parsed_grid_refinement.h
@@ -30,7 +30,6 @@
 #include <deal2lkit/config.h>
 #include <deal2lkit/parameter_acceptor.h>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -54,7 +53,7 @@ public:
    * Declare local parameters.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
 
   /**
@@ -68,7 +67,8 @@ public:
    */
   template <int dim, class Vector, int spacedim>
   void
-  mark_cells(const Vector &criteria, Triangulation<dim, spacedim> &tria) const;
+  mark_cells(const Vector &                        criteria,
+             dealii::Triangulation<dim, spacedim> &tria) const;
 
 #ifdef DEAL_II_WITH_MPI
 #  ifdef DEAL_II_WITH_P4EST
@@ -85,8 +85,9 @@ public:
    */
   template <int dim, class Vector, int spacedim>
   void
-  mark_cells(const Vector &                                       criteria,
-             parallel::distributed::Triangulation<dim, spacedim> &tria) const;
+  mark_cells(
+    const Vector &                                               criteria,
+    dealii::parallel::distributed::Triangulation<dim, spacedim> &tria) const;
 #  endif
 #endif
 
@@ -108,39 +109,44 @@ private:
 template <int dim, class Vector, int spacedim>
 void
 ParsedGridRefinement::mark_cells(
-  const Vector &                                       criteria,
-  parallel::distributed::Triangulation<dim, spacedim> &tria) const
+  const Vector &                                               criteria,
+  dealii::parallel::distributed::Triangulation<dim, spacedim> &tria) const
 {
   if (strategy == "number")
-    parallel::distributed::GridRefinement::refine_and_coarsen_fixed_number(
-      tria,
-      criteria,
-      top_parameter,
-      bottom_parameter,
-      max_cells ? max_cells : std::numeric_limits<unsigned int>::max());
+    dealii::parallel::distributed::GridRefinement::
+      refine_and_coarsen_fixed_number(
+        tria,
+        criteria,
+        top_parameter,
+        bottom_parameter,
+        max_cells ? max_cells : std::numeric_limits<unsigned int>::max());
   else if (strategy == "fraction")
-    parallel::distributed::GridRefinement::refine_and_coarsen_fixed_fraction(
-      tria, criteria, top_parameter, bottom_parameter);
+    dealii::parallel::distributed::GridRefinement::
+      refine_and_coarsen_fixed_fraction(tria,
+                                        criteria,
+                                        top_parameter,
+                                        bottom_parameter);
   else
-    Assert(false, ExcInternalError());
+    Assert(false, dealii::ExcInternalError());
 }
 #  endif
 #endif
 
 template <int dim, class Vector, int spacedim>
 void
-ParsedGridRefinement::mark_cells(const Vector &                criteria,
-                                 Triangulation<dim, spacedim> &tria) const
+ParsedGridRefinement::mark_cells(
+  const Vector &                        criteria,
+  dealii::Triangulation<dim, spacedim> &tria) const
 {
   if (strategy == "number")
-    GridRefinement::refine_and_coarsen_fixed_number(
+    dealii::GridRefinement::refine_and_coarsen_fixed_number(
       tria,
       criteria,
       top_parameter,
       bottom_parameter,
       max_cells ? max_cells : std::numeric_limits<unsigned int>::max());
   else if (strategy == "fraction")
-    GridRefinement::refine_and_coarsen_fixed_fraction(
+    dealii::GridRefinement::refine_and_coarsen_fixed_fraction(
       tria,
       criteria,
       top_parameter,
@@ -150,7 +156,7 @@ ParsedGridRefinement::mark_cells(const Vector &                criteria,
   // else if(strategy == "optimize")
   //   GridRefinement::refine_and_coarsen_optimize (tria, order);
   else
-    Assert(false, ExcInternalError());
+    Assert(false, dealii::ExcInternalError());
 }
 
 D2K_NAMESPACE_CLOSE

--- a/include/deal2lkit/parsed_kdtree_distance.h
+++ b/include/deal2lkit/parsed_kdtree_distance.h
@@ -26,7 +26,6 @@ DEAL_II_DISABLE_EXTRA_DIAGNOSTICS
 #include <external/nanoflann.h>
 DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
-using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -43,7 +42,8 @@ D2K_NAMESPACE_OPEN
  * raidius of a target point.
  */
 template <int dim>
-class ParsedKDTreeDistance : public ParameterAcceptor, public Function<dim>
+class ParsedKDTreeDistance : public ParameterAcceptor,
+                             public dealii::Function<dim>
 {
 public:
   /**
@@ -71,10 +71,10 @@ public:
    * your points, and do not call again set_points(), your results
    * will likely be wrong.
    */
-  ParsedKDTreeDistance(
-    const std::string &            name          = "",
-    const unsigned int &           max_leaf_size = 10,
-    const std::vector<Point<dim>> &pts           = std::vector<Point<dim>>());
+  ParsedKDTreeDistance(const std::string & name          = "",
+                       const unsigned int &max_leaf_size = 10,
+                       const std::vector<dealii::Point<dim>> &pts =
+                         std::vector<dealii::Point<dim>>());
 
 
   /**
@@ -94,14 +94,14 @@ public:
      * Reference to the vector of points from which we want to compute
      * the distance.
      */
-    const std::vector<Point<dim>>
+    const std::vector<dealii::Point<dim>>
       &points; //!< A const ref to the data set origin
 
 
     /**
      * The constrcutor needs the data set source.
      */
-    PointCloudAdaptor(const std::vector<Point<dim>> &_points)
+    PointCloudAdaptor(const std::vector<dealii::Point<dim>> &_points)
       : points(_points)
     {}
 
@@ -171,7 +171,7 @@ public:
    * Calls the underlying function of ParsedFunction.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
 
   /**
@@ -192,7 +192,7 @@ public:
    * with the constructor or with the method set_points()
    */
   virtual double
-  value(const Point<dim> &p, const unsigned int component = 0) const;
+  value(const dealii::Point<dim> &p, const unsigned int component = 0) const;
 
 
   /**
@@ -214,13 +214,13 @@ public:
    * @param pts: a collection of points
    */
   void
-  set_points(const std::vector<Point<dim>> &pts);
+  set_points(const std::vector<dealii::Point<dim>> &pts);
 
 
   /**
    * A const accessor to the underlying points.
    */
-  inline const Point<dim> &operator[](unsigned int i) const
+  inline const dealii::Point<dim> &operator[](unsigned int i) const
   {
     AssertIndexRange(i, size());
     return adaptor->points[i];
@@ -237,7 +237,7 @@ public:
       return adaptor->points.size();
     else
       return 0;
-  };
+  }
 
 
   /**
@@ -255,7 +255,7 @@ public:
    * @return number of points that are within the ball
    */
   unsigned int
-  get_points_within_ball(const Point<dim> &                            target,
+  get_points_within_ball(const dealii::Point<dim> &                    target,
                          const double &                                radius,
                          std::vector<std::pair<unsigned int, double>> &matches,
                          bool sorted = false) const;
@@ -272,7 +272,7 @@ public:
    * @param[out] distances: distances of the matching points
    */
   void
-  get_closest_points(const Point<dim> &         target,
+  get_closest_points(const dealii::Point<dim> & target,
                      std::vector<unsigned int> &indices,
                      std::vector<double> &      distances) const;
 

--- a/include/deal2lkit/parsed_mapped_functions.h
+++ b/include/deal2lkit/parsed_mapped_functions.h
@@ -29,7 +29,6 @@
 #include <algorithm>
 #include <map>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -123,7 +122,7 @@ public:
   /**
    * return the ComponentMask corresponding to the given id
    */
-  ComponentMask
+  dealii::ComponentMask
   get_mapped_mask(const unsigned int &id) const;
 
   /**
@@ -143,7 +142,7 @@ public:
    * declare_parameters is inherithed by ParameterAcceptor
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * parse_parameters_call_back is inherithed by ParameterAcceptor
@@ -214,22 +213,22 @@ protected:
   void
   set_normal_functions();
 
-  std::string                           name;
-  std::string                           str_id_components;
-  std::string                           str_id_functions;
-  std::string                           str_component_names;
-  std::string                           str_constants;
-  std::vector<std::string>              _component_names;
-  std::vector<std::string>              _normal_components;
-  std::vector<std::string>              _all_components;
-  std::vector<unsigned int>             ids;
-  std::vector<unsigned int>             normal_ids;
-  std::map<unsigned int, ComponentMask> id_components;
+  std::string                                   name;
+  std::string                                   str_id_components;
+  std::string                                   str_id_functions;
+  std::string                                   str_component_names;
+  std::string                                   str_constants;
+  std::vector<std::string>                      _component_names;
+  std::vector<std::string>                      _normal_components;
+  std::vector<std::string>                      _all_components;
+  std::vector<unsigned int>                     ids;
+  std::vector<unsigned int>                     normal_ids;
+  std::map<unsigned int, dealii::ComponentMask> id_components;
   std::map<unsigned int,
            shared_ptr<dealii::Functions::ParsedFunction<spacedim>>>
     id_functions;
   std::map<unsigned int,
-           std::pair<ComponentMask,
+           std::pair<dealii::ComponentMask,
                      shared_ptr<dealii::Functions::ParsedFunction<spacedim>>>>
     mapped_functions;
   std::map<std::string, std::pair<std::vector<unsigned int>, unsigned int>>

--- a/include/deal2lkit/parsed_preconditioner/amg.h
+++ b/include/deal2lkit/parsed_preconditioner/amg.h
@@ -28,7 +28,6 @@
 #  include <deal2lkit/parsed_finite_element.h>
 #  include <deal2lkit/utilities.h>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -40,7 +39,7 @@ D2K_NAMESPACE_OPEN
  * the preconditioner.
  */
 class ParsedAMGPreconditioner : public ParameterAcceptor,
-                                public TrilinosWrappers::PreconditionAMG
+                                public dealii::TrilinosWrappers::PreconditionAMG
 {
 public:
   /**
@@ -63,7 +62,7 @@ public:
    * Declare preconditioner options.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Initialize the preconditioner using @p matrix. Constant modes are not computed.
@@ -80,9 +79,9 @@ public:
   void
   initialize_preconditioner(const Matrix &                            matrix,
                             const ParsedFiniteElement<dim, spacedim> &fe,
-                            const DoFHandler<dim, spacedim> &         dh);
+                            const dealii::DoFHandler<dim, spacedim> & dh);
 
-  using TrilinosWrappers::PreconditionAMG::initialize;
+  using dealii::TrilinosWrappers::PreconditionAMG::initialize;
 
 private:
   /**

--- a/include/deal2lkit/parsed_preconditioner/amg_muelu.h
+++ b/include/deal2lkit/parsed_preconditioner/amg_muelu.h
@@ -28,7 +28,6 @@
 #  include <deal2lkit/parsed_finite_element.h>
 #  include <deal2lkit/utilities.h>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -41,7 +40,7 @@ D2K_NAMESPACE_OPEN
  */
 class ParsedAMGMueLuPreconditioner
   : public ParameterAcceptor,
-    public TrilinosWrappers::PreconditionAMGMueLu
+    public dealii::TrilinosWrappers::PreconditionAMGMueLu
 {
 public:
   /**
@@ -64,7 +63,7 @@ public:
    * Declare preconditioner options.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Initialize the preconditioner using @p matrix. Constant modes are not computed.
@@ -81,9 +80,9 @@ public:
   void
   initialize_preconditioner(const Matrix &                            matrix,
                             const ParsedFiniteElement<dim, spacedim> &fe,
-                            const DoFHandler<dim, spacedim> &         dh);
+                            const dealii::DoFHandler<dim, spacedim> & dh);
 
-  using TrilinosWrappers::PreconditionAMGMueLu::initialize;
+  using dealii::TrilinosWrappers::PreconditionAMGMueLu::initialize;
 
 private:
   /**

--- a/include/deal2lkit/parsed_preconditioner/ilu.h
+++ b/include/deal2lkit/parsed_preconditioner/ilu.h
@@ -28,9 +28,6 @@
 #  include <deal2lkit/parsed_finite_element.h>
 #  include <deal2lkit/utilities.h>
 
-using namespace dealii;
-
-
 D2K_NAMESPACE_OPEN
 
 /**
@@ -40,7 +37,7 @@ D2K_NAMESPACE_OPEN
  * of the preconditioner.
  */
 class ParsedILUPreconditioner : public ParameterAcceptor,
-                                public TrilinosWrappers::PreconditionILU
+                                public dealii::TrilinosWrappers::PreconditionILU
 {
 public:
   /**
@@ -56,7 +53,7 @@ public:
    * Declare preconditioner options.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Initialize the preconditioner using @p matrix.
@@ -65,7 +62,7 @@ public:
   void
   initialize_preconditioner(const Matrix &matrix);
 
-  using TrilinosWrappers::PreconditionILU::initialize;
+  using dealii::TrilinosWrappers::PreconditionILU::initialize;
 
 private:
   /**

--- a/include/deal2lkit/parsed_preconditioner/jacobi.h
+++ b/include/deal2lkit/parsed_preconditioner/jacobi.h
@@ -28,9 +28,6 @@
 #  include <deal2lkit/parsed_finite_element.h>
 #  include <deal2lkit/utilities.h>
 
-using namespace dealii;
-
-
 D2K_NAMESPACE_OPEN
 
 /**
@@ -39,8 +36,9 @@ D2K_NAMESPACE_OPEN
  * TrilinosWrappers::PreconditionJacobi which can be called in place
  * of the preconditioner.
  */
-class ParsedJacobiPreconditioner : public ParameterAcceptor,
-                                   public TrilinosWrappers::PreconditionJacobi
+class ParsedJacobiPreconditioner
+  : public ParameterAcceptor,
+    public dealii::TrilinosWrappers::PreconditionJacobi
 {
 public:
   /**
@@ -55,7 +53,7 @@ public:
    * Declare preconditioner options.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Initialize the preconditioner using @p matrix.
@@ -64,7 +62,7 @@ public:
   void
   initialize_preconditioner(const Matrix &matrix);
 
-  using TrilinosWrappers::PreconditionJacobi::initialize;
+  using dealii::TrilinosWrappers::PreconditionJacobi::initialize;
 
 private:
   /**

--- a/include/deal2lkit/parsed_quadrature.h
+++ b/include/deal2lkit/parsed_quadrature.h
@@ -20,7 +20,6 @@
 
 #include <deal2lkit/parameter_acceptor.h>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -31,7 +30,8 @@ D2K_NAMESPACE_OPEN
  * dimension of the quadrature.
  */
 template <int dim>
-class ParsedQuadrature : public Quadrature<dim>, public ParameterAcceptor
+class ParsedQuadrature : public dealii::Quadrature<dim>,
+                         public ParameterAcceptor
 {
 public:
   /**
@@ -64,7 +64,7 @@ public:
    * Declare quadrature type and quadrature options.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Fill information about blocks after parsing the parameters.

--- a/include/deal2lkit/parsed_solver.h
+++ b/include/deal2lkit/parsed_solver.h
@@ -32,7 +32,6 @@
 #include <deal2lkit/parameter_acceptor.h>
 #include <deal2lkit/utilities.h>
 
-using namespace dealii;
 
 
 D2K_NAMESPACE_OPEN
@@ -43,7 +42,7 @@ default_reinit()
 {
   return [](VECTOR &, bool) {
     Assert(false,
-           ExcInternalError(
+           dealii::ExcInternalError(
              "It seems you really need to set a ReinitFunction for your "
              "operator. Try avoiding PackagedOperator if you don't want "
              "to implement this function."));
@@ -69,7 +68,7 @@ default_reinit()
  * @endcode
  */
 template <typename VECTOR>
-class ParsedSolver : public LinearOperator<VECTOR, VECTOR>,
+class ParsedSolver : public dealii::LinearOperator<VECTOR, VECTOR>,
                      public ParameterAcceptor
 {
 public:
@@ -81,26 +80,26 @@ public:
    * will need, you can also supply them here. They default to the
    * identity, and you can assign them later by setting op and prec.
    */
-  ParsedSolver(const std::string &           name           = "",
-               const std::string &           default_solver = "cg",
-               const unsigned int            iter           = 1000,
-               const double                  reduction      = 1e-8,
-               const LinearOperator<VECTOR> &op =
-                 identity_operator<VECTOR>(default_reinit<VECTOR>()),
-               const LinearOperator<VECTOR> &prec =
-                 identity_operator<VECTOR>(default_reinit<VECTOR>()));
+  ParsedSolver(const std::string &                   name           = "",
+               const std::string &                   default_solver = "cg",
+               const unsigned int                    iter           = 1000,
+               const double                          reduction      = 1e-8,
+               const dealii::LinearOperator<VECTOR> &op =
+                 dealii::identity_operator<VECTOR>(default_reinit<VECTOR>()),
+               const dealii::LinearOperator<VECTOR> &prec =
+                 dealii::identity_operator<VECTOR>(default_reinit<VECTOR>()));
 
   /**
    * Declare solver type and solver options.
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Parse solver type and solver options.
    */
   virtual void
-  parse_parameters(ParameterHandler &prm);
+  parse_parameters(dealii::ParameterHandler &prm);
 
   /**
    * Initialize internal variables.
@@ -114,19 +113,19 @@ public:
    * construction time, or by this->op = some_new_op. By default it is
    * the identity operator.
    */
-  LinearOperator<VECTOR> op;
+  dealii::LinearOperator<VECTOR> op;
 
   /**
    * The preconditioner used by this solver. You can assign a new one
    * at construction time, or by this->op = some_new_op.  By default
    * it is the identity operator.
    */
-  LinearOperator<VECTOR> prec;
+  dealii::LinearOperator<VECTOR> prec;
 
   /**
    * ReductionControl. Used internally by the solver.
    */
-  ReductionControl control;
+  dealii::ReductionControl control;
 
 private:
   /**
@@ -156,7 +155,7 @@ private:
   /**
    * The actual solver.
    */
-  shared_ptr<Solver<VECTOR>> solver;
+  shared_ptr<dealii::Solver<VECTOR>> solver;
 };
 
 // ============================================================
@@ -168,8 +167,8 @@ ParsedSolver<VECTOR>::ParsedSolver(const std::string &name,
                                    const std::string &default_solver,
                                    const unsigned int default_iter,
                                    const double       default_reduction,
-                                   const LinearOperator<VECTOR> &op,
-                                   const LinearOperator<VECTOR> &prec)
+                                   const dealii::LinearOperator<VECTOR> &op,
+                                   const dealii::LinearOperator<VECTOR> &prec)
   : ParameterAcceptor(name)
   , op(op)
   , prec(prec)
@@ -181,17 +180,17 @@ ParsedSolver<VECTOR>::ParsedSolver(const std::string &name,
 
 template <typename VECTOR>
 void
-ParsedSolver<VECTOR>::declare_parameters(ParameterHandler &prm)
+ParsedSolver<VECTOR>::declare_parameters(dealii::ParameterHandler &prm)
 {
   add_parameter(prm,
                 &solver_name,
                 "Solver name",
                 solver_name,
-                Patterns::Selection("cg|bicgstab|gmres|fgmres|"
-                                    "minres|qmrs|richardson"),
+                dealii::Patterns::Selection("cg|bicgstab|gmres|fgmres|"
+                                            "minres|qmrs|richardson"),
                 "Name of the solver to use.");
 
-  ReductionControl::declare_parameters(prm);
+  dealii::ReductionControl::declare_parameters(prm);
 
   prm.set("Max steps", std::to_string(max_iterations));
   prm.set("Reduction", reduction);
@@ -200,7 +199,7 @@ ParsedSolver<VECTOR>::declare_parameters(ParameterHandler &prm)
 
 template <typename VECTOR>
 void
-ParsedSolver<VECTOR>::parse_parameters(ParameterHandler &prm)
+ParsedSolver<VECTOR>::parse_parameters(dealii::ParameterHandler &prm)
 {
   ParameterAcceptor::parse_parameters(prm);
   control.parse_parameters(prm);
@@ -212,8 +211,9 @@ template <typename MySolver>
 void
 ParsedSolver<VECTOR>::initialize_solver(MySolver *s)
 {
-  solver                                    = SP(s);
-  (LinearOperator<VECTOR, VECTOR> &)(*this) = inverse_operator(op, *s, prec);
+  solver = SP(s);
+  (dealii::LinearOperator<VECTOR, VECTOR> &)(*this) =
+    dealii::inverse_operator(op, *s, prec);
 }
 
 template <typename VECTOR>
@@ -222,35 +222,35 @@ ParsedSolver<VECTOR>::parse_parameters_call_back()
 {
   if (solver_name == "cg")
     {
-      initialize_solver(new SolverCG<VECTOR>(control));
+      initialize_solver(new dealii::SolverCG<VECTOR>(control));
     }
   else if (solver_name == "bicgstab")
     {
-      initialize_solver(new SolverBicgstab<VECTOR>(control));
+      initialize_solver(new dealii::SolverBicgstab<VECTOR>(control));
     }
   else if (solver_name == "gmres")
     {
-      initialize_solver(new SolverGMRES<VECTOR>(control));
+      initialize_solver(new dealii::SolverGMRES<VECTOR>(control));
     }
   else if (solver_name == "fgmres")
     {
-      initialize_solver(new SolverFGMRES<VECTOR>(control));
+      initialize_solver(new dealii::SolverFGMRES<VECTOR>(control));
     }
   else if (solver_name == "minres")
     {
-      initialize_solver(new SolverMinRes<VECTOR>(control));
+      initialize_solver(new dealii::SolverMinRes<VECTOR>(control));
     }
   else if (solver_name == "qmrs")
     {
-      initialize_solver(new SolverQMRS<VECTOR>(control));
+      initialize_solver(new dealii::SolverQMRS<VECTOR>(control));
     }
   else if (solver_name == "richardson")
     {
-      initialize_solver(new SolverRichardson<VECTOR>(control));
+      initialize_solver(new dealii::SolverRichardson<VECTOR>(control));
     }
   else
     {
-      Assert(false, ExcInternalError("Solver should not be unknonw."));
+      Assert(false, dealii::ExcInternalError("Solver should not be unknonw."));
     }
 }
 

--- a/include/deal2lkit/parsed_zero_average_constraints.h
+++ b/include/deal2lkit/parsed_zero_average_constraints.h
@@ -33,9 +33,6 @@
 #include <map>
 
 
-using namespace dealii;
-
-
 D2K_NAMESPACE_OPEN
 
 /**
@@ -101,21 +98,22 @@ public:
    * constraint matrix
    */
   void
-  apply_zero_average_constraints(const DoFHandler<dim, spacedim> &dof_handler,
-                                 ConstraintMatrix &constraints) const;
+  apply_zero_average_constraints(
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    dealii::ConstraintMatrix &               constraints) const;
 
 
   /**
    * return the ComponentMask at boundary
    */
-  ComponentMask
+  dealii::ComponentMask
   get_boundary_mask() const;
 
 
   /**
    * return the ComponentMask
    */
-  ComponentMask
+  dealii::ComponentMask
   get_mask() const;
 
 
@@ -123,7 +121,7 @@ public:
    * declare_parameters is inherithed by ParameterAcceptor
    */
   virtual void
-  declare_parameters(ParameterHandler &prm);
+  declare_parameters(dealii::ParameterHandler &prm);
 
   /**
    * parse_parameters_call_back is inherithed by ParameterAcceptor
@@ -151,10 +149,10 @@ public:
 protected:
   void
   internal_zero_average_constraints(
-    const DoFHandler<dim, spacedim> &dof_handler,
-    const ComponentMask              mask,
-    const bool                       at_boundary,
-    ConstraintMatrix &               constraints) const;
+    const dealii::DoFHandler<dim, spacedim> &dof_handler,
+    const dealii::ComponentMask              mask,
+    const bool                               at_boundary,
+    dealii::ConstraintMatrix &               constraints) const;
 
   std::string              name;
   std::string              str_components;

--- a/include/deal2lkit/sacado_tools.h
+++ b/include/deal2lkit/sacado_tools.h
@@ -37,8 +37,6 @@ typedef Sacado::Fad::DFad<Sdouble> SSdouble;
 
 #  include <deal.II/base/tensor.h>
 
-using namespace dealii;
-
 
 
 D2K_NAMESPACE_OPEN
@@ -47,13 +45,13 @@ namespace SacadoTools
 {
   /**
    * This function compute the scalar product
-   * between two tensors with rank 1 of different types
+   * between two dealii::Tensors with rank 1 of different types
    *  i.e., Number and double  returning a Number.
    */
   template <int dim, typename Number>
   Number
-  scalar_product(const Tensor<1, dim, Number> &T1,
-                 const Tensor<1, dim, double> &T2)
+  scalar_product(const dealii::Tensor<1, dim, Number> &T1,
+                 const dealii::Tensor<1, dim, double> &T2)
   {
     Number ret = 0;
     for (unsigned int i = 0; i < dim; ++i)
@@ -65,13 +63,13 @@ namespace SacadoTools
 
   /**
    * This function compute the scalar product
-   * between two tensors with rank 1 of different types
+   * between two dealii::Tensors with rank 1 of different types
    *  i.e., Number and double  returning a Number.
    */
   template <int dim, typename Number>
   Number
-  scalar_product(const Tensor<1, dim, double> &T1,
-                 const Tensor<1, dim, Number> &T2)
+  scalar_product(const dealii::Tensor<1, dim, double> &T1,
+                 const dealii::Tensor<1, dim, Number> &T2)
   {
     return SacadoTools::scalar_product(T2, T1);
   }
@@ -83,8 +81,8 @@ namespace SacadoTools
    */
   template <int dim>
   double
-  scalar_product(const Tensor<1, dim, double> &T1,
-                 const Tensor<1, dim, double> &T2)
+  scalar_product(const dealii::Tensor<1, dim, double> &T1,
+                 const dealii::Tensor<1, dim, double> &T2)
   {
     return T1 * T2;
   }
@@ -93,13 +91,13 @@ namespace SacadoTools
 
   /**
    * This function compute the scalar product
-   * between two tensors with rank 2 of different types
+   * between two dealii::Tensors with rank 2 of different types
    *  i.e., Number and double  returning a Number.
    */
   template <int dim, typename Number>
   Number
-  scalar_product(const Tensor<2, dim, Number> &T1,
-                 const Tensor<2, dim, double> &T2)
+  scalar_product(const dealii::Tensor<2, dim, Number> &T1,
+                 const dealii::Tensor<2, dim, double> &T2)
   {
     Number ret = 0;
     for (unsigned int i = 0; i < dim; ++i)
@@ -112,13 +110,13 @@ namespace SacadoTools
 
   /**
    * This function compute the scalar product
-   * between two tensors with rank 2 of different types
+   * between two dealii::Tensors with rank 2 of different types
    *  i.e., Number and double  returning a Number.
    */
   template <int dim, typename Number>
   Number
-  scalar_product(const Tensor<2, dim, double> &T1,
-                 const Tensor<2, dim, Number> &T2)
+  scalar_product(const dealii::Tensor<2, dim, double> &T1,
+                 const dealii::Tensor<2, dim, Number> &T2)
   {
     return SacadoTools::scalar_product(T2, T1);
   }
@@ -130,8 +128,8 @@ namespace SacadoTools
    */
   template <int dim>
   double
-  scalar_product(const Tensor<2, dim, double> &T1,
-                 const Tensor<2, dim, double> &T2)
+  scalar_product(const dealii::Tensor<2, dim, double> &T1,
+                 const dealii::Tensor<2, dim, double> &T2)
   {
     return dealii::scalar_product(T1, T2);
   }
@@ -164,14 +162,14 @@ namespace SacadoTools
 
 
   /**
-   * Downgrade from Tensor<index,dim,Sacado<number> > to
-   * Tensor<index,dim,number>
+   * Downgrade from dealii::Tensor<index,dim,Sacado<number> > to
+   * dealii::Tensor<index,dim,number>
    */
   template <int index, int dim, typename number>
-  Tensor<index, dim, number>
-  val(const Tensor<index, dim, Sacado::Fad::DFad<number>> &T)
+  dealii::Tensor<index, dim, number>
+  val(const dealii::Tensor<index, dim, Sacado::Fad::DFad<number>> &T)
   {
-    Tensor<index, dim, number> ret;
+    dealii::Tensor<index, dim, number> ret;
     for (unsigned int i = 0; i < dim; ++i)
       ret[i] = val(T[i]);
     return ret;
@@ -180,14 +178,15 @@ namespace SacadoTools
 
 
   /**
-   * Downgrade a std::vector<Tensor<index,dim,Sacado<number> > > to
-   * std::vector<Tensor<index,dim, number> >
+   * Downgrade a std::vector<dealii::Tensor<index,dim,Sacado<number> > > to
+   * std::vector<dealii::Tensor<index,dim, number> >
    */
   template <int index, int dim, typename number>
-  std::vector<Tensor<index, dim, number>>
-  val(const std::vector<Tensor<index, dim, Sacado::Fad::DFad<number>>> &T)
+  std::vector<dealii::Tensor<index, dim, number>>
+  val(
+    const std::vector<dealii::Tensor<index, dim, Sacado::Fad::DFad<number>>> &T)
   {
-    std::vector<Tensor<index, dim, number>> ret(T.size());
+    std::vector<dealii::Tensor<index, dim, number>> ret(T.size());
     for (unsigned int q = 0; q < T.size(); ++q)
       ret[q] = val(T[q]);
     return ret;
@@ -249,8 +248,8 @@ namespace SacadoTools
    * Do nothing, required for compatibility.
    */
   template <int index, int dim>
-  Tensor<index, dim>
-  to_double(const Tensor<index, dim> &t)
+  dealii::Tensor<index, dim>
+  to_double(const dealii::Tensor<index, dim> &t)
   {
     return t;
   }
@@ -258,14 +257,15 @@ namespace SacadoTools
 
 
   /**
-   * Return a Tensor<index,dim,double> given a Tensor<index,dim,Sdouble<number>
-   * > where T can be double, Sdouble, etc.
+   * Return a dealii::Tensor<index,dim,double> given a
+   * dealii::Tensor<index,dim,Sdouble<number> > where T can be double, Sdouble,
+   * etc.
    */
   template <int index, int dim, typename number>
-  Tensor<index, dim>
-  to_double(const Tensor<index, dim, Sacado::Fad::DFad<number>> &t)
+  dealii::Tensor<index, dim>
+  to_double(const dealii::Tensor<index, dim, Sacado::Fad::DFad<number>> &t)
   {
-    Tensor<index, dim> ret;
+    dealii::Tensor<index, dim> ret;
     for (unsigned int i = 0; i < dim; ++i)
       ret[i] = to_double(t[i]);
     return ret;
@@ -274,15 +274,16 @@ namespace SacadoTools
 
 
   /**
-   * Return a std::vector<Tensor<index,dim,double> > given a
-   * std::vector<Tensor<index,dim,Sdouble<T> > > where T can be
+   * Return a std::vector<dealii::Tensor<index,dim,double> > given a
+   * std::vector<dealii::Tensor<index,dim,Sdouble<T> > > where T can be
    * double, Sdouble etc.
    */
   template <int index, int dim, typename number>
-  std::vector<Tensor<index, dim>>
-  to_double(const std::vector<Tensor<index, dim, Sacado::Fad::DFad<number>>> &v)
+  std::vector<dealii::Tensor<index, dim>>
+  to_double(
+    const std::vector<dealii::Tensor<index, dim, Sacado::Fad::DFad<number>>> &v)
   {
-    std::vector<Tensor<index, dim>> ret(v.size());
+    std::vector<dealii::Tensor<index, dim>> ret(v.size());
     for (unsigned int q = 0; q < v.size(); ++q)
       ret[q] = to_double(v[q]);
     return ret;

--- a/include/deal2lkit/utilities.h
+++ b/include/deal2lkit/utilities.h
@@ -57,8 +57,8 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 
 
 #include <deal.II/base/index_set.h>
-using namespace dealii;
-using std_cxx11::shared_ptr;
+using std::shared_ptr;
+using std::unique_ptr;
 
 
 D2K_NAMESPACE_OPEN
@@ -113,7 +113,7 @@ public:
   {
     AssertThrow(
       num < times.size(),
-      ExcMessage(
+      dealii::ExcMessage(
         "Invalind number num. It is higher than the number of times."));
 
     return times[num];
@@ -484,7 +484,7 @@ print(const std::vector<Type> &list, const std::string sep = ",")
  */
 template <int dim>
 std::string
-print(const Point<dim> &point, const std::string sep = ",")
+print(const dealii::Point<dim> &point, const std::string sep = ",")
 {
   std::stringstream ret;
   ret << point[0];
@@ -570,32 +570,32 @@ vector_shift(VEC &in_vec, double a_scalar)
 
 #    ifdef DEAL_II_WITH_TRILINOS
 void
-copy(TrilinosWrappers::MPI::Vector &dst, const N_Vector &src);
+copy(dealii::TrilinosWrappers::MPI::Vector &dst, const N_Vector &src);
 void
-copy(N_Vector &dst, const TrilinosWrappers::MPI::Vector &src);
+copy(N_Vector &dst, const dealii::TrilinosWrappers::MPI::Vector &src);
 void
-copy(TrilinosWrappers::MPI::BlockVector &dst, const N_Vector &src);
+copy(dealii::TrilinosWrappers::MPI::BlockVector &dst, const N_Vector &src);
 void
-copy(N_Vector &dst, const TrilinosWrappers::MPI::BlockVector &src);
+copy(N_Vector &dst, const dealii::TrilinosWrappers::MPI::BlockVector &src);
 #    endif // DEAL_II_WITH_TRILINOS
 
 #    ifdef DEAL_II_WITH_PETSC
 void
-copy(PETScWrappers::MPI::Vector &dst, const N_Vector &src);
+copy(dealii::PETScWrappers::MPI::Vector &dst, const N_Vector &src);
 void
-copy(N_Vector &dst, const PETScWrappers::MPI::Vector &src);
+copy(N_Vector &dst, const dealii::PETScWrappers::MPI::Vector &src);
 void
-copy(PETScWrappers::MPI::BlockVector &dst, const N_Vector &src);
+copy(dealii::PETScWrappers::MPI::BlockVector &dst, const N_Vector &src);
 void
-copy(N_Vector &dst, const PETScWrappers::MPI::BlockVector &src);
+copy(N_Vector &dst, const dealii::PETScWrappers::MPI::BlockVector &src);
 #    endif // DEAL_II_WITH_PETSC
 
 #  endif
 
 void
-copy(BlockVector<double> &dst, const N_Vector &src);
+copy(dealii::BlockVector<double> &dst, const N_Vector &src);
 void
-copy(N_Vector &dst, const BlockVector<double> &src);
+copy(N_Vector &dst, const dealii::BlockVector<double> &src);
 
 #endif
 
@@ -616,11 +616,11 @@ public:
   TimeMonitor(const MPI_Comm &comm   = MPI_COMM_WORLD,
               std::ostream &  stream = std::cout)
     : outstream(stream)
-    , out(outstream, Utilities::MPI::this_mpi_process(comm) == 0)
+    , out(outstream, dealii::Utilities::MPI::this_mpi_process(comm) == 0)
     , dealii_timer(comm,
                    out,
-                   TimerOutput::never,
-                   TimerOutput::cpu_and_wall_times)
+                   dealii::TimerOutput::never,
+                   dealii::TimerOutput::cpu_and_wall_times)
   {}
 
   /**
@@ -643,9 +643,9 @@ public:
     /**
      * Start Trilinos and deal.II scoped monitors.
      */
-    Scope(Teuchos::Time &    trilinos_time,
-          TimerOutput &      dealii_timer_output,
-          const std::string &section)
+    Scope(Teuchos::Time &      trilinos_time,
+          dealii::TimerOutput &dealii_timer_output,
+          const std::string &  section)
       : trilinos_scoped_monitor(trilinos_time)
       , dealii_scoped_monitor(dealii_timer_output, section)
     {}
@@ -659,7 +659,7 @@ public:
     /**
      * Deal.II version of scoped monitor.
      */
-    TimerOutput::Scope dealii_scoped_monitor;
+    dealii::TimerOutput::Scope dealii_scoped_monitor;
   };
 
   /**
@@ -685,7 +685,7 @@ private:
   /**
    * Conditional output stream. Output is only generated on processor 0.
    */
-  ConditionalOStream out;
+  dealii::ConditionalOStream out;
 
   /**
    * A list of Trilinos timers.
@@ -695,7 +695,7 @@ private:
   /**
    * The deal.II TimeMonitor object.
    */
-  mutable TimerOutput dealii_timer;
+  mutable dealii::TimerOutput dealii_timer;
 };
 #endif
 

--- a/source/error_handler.cc
+++ b/source/error_handler.cc
@@ -35,6 +35,7 @@
 #include <string>
 #include <vector>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/ida_interface.cc
+++ b/source/ida_interface.cc
@@ -37,9 +37,7 @@
 #  include <iomanip>
 #  include <iostream>
 
-
 using namespace dealii;
-
 
 D2K_NAMESPACE_OPEN
 

--- a/source/imex_stepper.cc
+++ b/source/imex_stepper.cc
@@ -42,7 +42,6 @@
 
 using namespace dealii;
 
-
 D2K_NAMESPACE_OPEN
 
 #  ifdef DEAL_II_WITH_MPI

--- a/source/kinsol_interface.cc
+++ b/source/kinsol_interface.cc
@@ -35,6 +35,8 @@
 #  include <deal2lkit/utilities.h>
 #  include <kinsol/kinsol_dense.h>
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 // protect the helper functions

--- a/source/parameter_acceptor.cc
+++ b/source/parameter_acceptor.cc
@@ -23,6 +23,8 @@
 
 #include <fstream>
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 

--- a/source/parsed_data_out.cc
+++ b/source/parsed_data_out.cc
@@ -38,6 +38,7 @@ DEAL_II_ENABLE_EXTRA_DIAGNOSTICS
 #include <string>
 #include <vector>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/parsed_dirichlet_bcs.cc
+++ b/source/parsed_dirichlet_bcs.cc
@@ -15,11 +15,9 @@
 
 #include <deal2lkit/parsed_dirichlet_bcs.h>
 
-
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
-
-
 
 template <int dim, int spacedim>
 ParsedDirichletBCs<dim, spacedim>::ParsedDirichletBCs(
@@ -126,28 +124,25 @@ ParsedDirichletBCs<dim, spacedim>::interpolate_boundary_values(
 // [TODO] Fix this in deal.II.
 
 template <>
-void ParsedDirichletBCs<1, 2>::project_boundary_values(
-  dealii::DoFHandler<1, 2> const &,
-  dealii::Quadrature<0> const &,
-  dealii::ConstraintMatrix &) const
+void ParsedDirichletBCs<1, 2>::project_boundary_values(DoFHandler<1, 2> const &,
+                                                       Quadrature<0> const &,
+                                                       ConstraintMatrix &) const
 {
   ExcImpossibleInDim(1);
 }
 
 template <>
-void ParsedDirichletBCs<1, 3>::project_boundary_values(
-  dealii::DoFHandler<1, 3> const &,
-  dealii::Quadrature<0> const &,
-  dealii::ConstraintMatrix &) const
+void ParsedDirichletBCs<1, 3>::project_boundary_values(DoFHandler<1, 3> const &,
+                                                       Quadrature<0> const &,
+                                                       ConstraintMatrix &) const
 {
   ExcImpossibleInDim(1);
 }
 
 template <>
-void ParsedDirichletBCs<2, 3>::project_boundary_values(
-  dealii::DoFHandler<2, 3> const &,
-  dealii::Quadrature<1> const &,
-  dealii::ConstraintMatrix &) const
+void ParsedDirichletBCs<2, 3>::project_boundary_values(DoFHandler<2, 3> const &,
+                                                       Quadrature<1> const &,
+                                                       ConstraintMatrix &) const
 {
   ExcNotImplemented();
 }
@@ -155,22 +150,20 @@ void ParsedDirichletBCs<2, 3>::project_boundary_values(
 
 template <>
 void
-ParsedDirichletBCs<1, 2>::project_boundary_values(
-  const Mapping<1, 2> &,
-  dealii::DoFHandler<1, 2> const &,
-  dealii::Quadrature<0> const &,
-  dealii::ConstraintMatrix &) const
+ParsedDirichletBCs<1, 2>::project_boundary_values(const Mapping<1, 2> &,
+                                                  DoFHandler<1, 2> const &,
+                                                  Quadrature<0> const &,
+                                                  ConstraintMatrix &) const
 {
   ExcImpossibleInDim(1);
 }
 
 template <>
 void
-ParsedDirichletBCs<1, 3>::project_boundary_values(
-  const Mapping<1, 3> &,
-  dealii::DoFHandler<1, 3> const &,
-  dealii::Quadrature<0> const &,
-  dealii::ConstraintMatrix &) const
+ParsedDirichletBCs<1, 3>::project_boundary_values(const Mapping<1, 3> &,
+                                                  DoFHandler<1, 3> const &,
+                                                  Quadrature<0> const &,
+                                                  ConstraintMatrix &) const
 {
   ExcImpossibleInDim(1);
 }
@@ -179,11 +172,10 @@ ParsedDirichletBCs<1, 3>::project_boundary_values(
 
 template <>
 void
-ParsedDirichletBCs<2, 3>::project_boundary_values(
-  const Mapping<2, 3> &,
-  dealii::DoFHandler<2, 3> const &,
-  dealii::Quadrature<1> const &,
-  dealii::ConstraintMatrix &) const
+ParsedDirichletBCs<2, 3>::project_boundary_values(const Mapping<2, 3> &,
+                                                  DoFHandler<2, 3> const &,
+                                                  Quadrature<1> const &,
+                                                  ConstraintMatrix &) const
 {
   ExcNotImplemented();
 }
@@ -404,7 +396,7 @@ ParsedDirichletBCs<1, 1>::compute_no_normal_flux_constraints(
 
 template <>
 void ParsedDirichletBCs<1, 1>::compute_nonzero_normal_flux_constraints(
-  dealii::DoFHandler<1, 1> const &,
+  DoFHandler<1, 1> const &,
   ConstraintMatrix &) const
 {
   Assert(false, ExcImpossibleInDim(1));
@@ -445,7 +437,7 @@ ParsedDirichletBCs<1, 2>::compute_no_normal_flux_constraints(
 
 template <>
 void ParsedDirichletBCs<1, 2>::compute_nonzero_normal_flux_constraints(
-  dealii::DoFHandler<1, 2> const &,
+  DoFHandler<1, 2> const &,
   ConstraintMatrix &) const
 {
   Assert(false, ExcImpossibleInDim(1));
@@ -485,7 +477,7 @@ ParsedDirichletBCs<1, 3>::compute_no_normal_flux_constraints(
 
 template <>
 void ParsedDirichletBCs<1, 3>::compute_nonzero_normal_flux_constraints(
-  dealii::DoFHandler<1, 3> const &,
+  DoFHandler<1, 3> const &,
   ConstraintMatrix &) const
 {
   Assert(false, ExcImpossibleInDim(1));
@@ -526,7 +518,7 @@ ParsedDirichletBCs<2, 3>::compute_no_normal_flux_constraints(
 
 template <>
 void ParsedDirichletBCs<2, 3>::compute_nonzero_normal_flux_constraints(
-  dealii::DoFHandler<2, 3> const &,
+  DoFHandler<2, 3> const &,
   ConstraintMatrix &) const
 {
   Assert(false, ExcImpossibleInDim(2));

--- a/source/parsed_finite_element.cc
+++ b/source/parsed_finite_element.cc
@@ -20,6 +20,8 @@
 
 #include <algorithm> // std::find
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 template <int dim, int spacedim>

--- a/source/parsed_function.cc
+++ b/source/parsed_function.cc
@@ -16,6 +16,7 @@
 #include <deal2lkit/parsed_function.h>
 #include <deal2lkit/utilities.h>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 
@@ -25,7 +26,7 @@ ParsedFunction<dim>::ParsedFunction(const std::string & name,
                                     const std::string & default_exp,
                                     const std::string & default_const)
   : ParameterAcceptor(name)
-  , Functions::ParsedFunction<dim>(n_components)
+  , dealii::Functions::ParsedFunction<dim>(n_components)
   , default_exp(default_exp)
   , default_const(default_const)
   , n_components(n_components)
@@ -34,9 +35,9 @@ ParsedFunction<dim>::ParsedFunction(const std::string & name,
 
 template <int dim>
 void
-ParsedFunction<dim>::declare_parameters(ParameterHandler &prm)
+ParsedFunction<dim>::declare_parameters(dealii::ParameterHandler &prm)
 {
-  Functions::ParsedFunction<dim>::declare_parameters(prm, n_components);
+  dealii::Functions::ParsedFunction<dim>::declare_parameters(prm, n_components);
   if (default_exp != "")
     prm.set("Function expression", default_exp);
   if (default_const != "")
@@ -46,9 +47,9 @@ ParsedFunction<dim>::declare_parameters(ParameterHandler &prm)
 
 template <int dim>
 void
-ParsedFunction<dim>::parse_parameters(ParameterHandler &prm)
+ParsedFunction<dim>::parse_parameters(dealii::ParameterHandler &prm)
 {
-  Functions::ParsedFunction<dim>::parse_parameters(prm);
+  dealii::Functions::ParsedFunction<dim>::parse_parameters(prm);
 }
 
 

--- a/source/parsed_grid_generator.cc
+++ b/source/parsed_grid_generator.cc
@@ -54,6 +54,8 @@ namespace
   }
 } // namespace
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 

--- a/source/parsed_grid_refinement.cc
+++ b/source/parsed_grid_refinement.cc
@@ -15,7 +15,7 @@
 
 #include <deal2lkit/parsed_grid_refinement.h>
 
-
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/parsed_mapped_functions.cc
+++ b/source/parsed_mapped_functions.cc
@@ -15,6 +15,7 @@
 
 #include <deal2lkit/parsed_mapped_functions.h>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/parsed_preconditioner/amg.cc
+++ b/source/parsed_preconditioner/amg.cc
@@ -18,9 +18,9 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
-
 #  include <deal.II/dofs/dof_tools.h>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/parsed_preconditioner/amg_muelu.cc
+++ b/source/parsed_preconditioner/amg_muelu.cc
@@ -21,6 +21,7 @@
 
 #  include <deal.II/dofs/dof_tools.h>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/parsed_preconditioner/ilu.cc
+++ b/source/parsed_preconditioner/ilu.cc
@@ -17,6 +17,8 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 ParsedILUPreconditioner::ParsedILUPreconditioner(const std::string & name,

--- a/source/parsed_preconditioner/jacobi.cc
+++ b/source/parsed_preconditioner/jacobi.cc
@@ -17,6 +17,8 @@
 
 #ifdef DEAL_II_WITH_TRILINOS
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 ParsedJacobiPreconditioner::ParsedJacobiPreconditioner(

--- a/source/parsed_quadrature.cc
+++ b/source/parsed_quadrature.cc
@@ -17,6 +17,8 @@
 
 #include <deal2lkit/parsed_quadrature.h>
 
+using namespace dealii;
+
 D2K_NAMESPACE_OPEN
 
 template <int dim>

--- a/source/parsed_zero_average_constraints.cc
+++ b/source/parsed_zero_average_constraints.cc
@@ -17,7 +17,7 @@
 
 #include <deal2lkit/parsed_zero_average_constraints.h>
 
-
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
 

--- a/source/utilities.cc
+++ b/source/utilities.cc
@@ -21,9 +21,9 @@
 #include <thread>
 #include <vector>
 
+using namespace dealii;
 
 D2K_NAMESPACE_OPEN
-
 
 std::string
 demangle(const char *name)


### PR DESCRIPTION
This makes sure that the deal.II library namespace is not forced into users. Important, for example, if the user wants to use dealii::ParameterAcceptor instead of deal2lkit::ParameterAcceptor.