### PR TITLE
Make AffineConstraints work with dealii 9.0

### DIFF
--- a/include/deal2lkit/parsed_dirichlet_bcs.h
+++ b/include/deal2lkit/parsed_dirichlet_bcs.h
@@ -20,7 +20,27 @@
 
 #include <deal.II/dofs/dof_handler.h>
 
-#include <deal.II/lac/affine_constraints.h>
+// old versions of dealii use ConstraintMatrix but the new versions
+// have switched to AffineConstraints<double>
+#if DEAL_II_VERSION_GTE(9, 1, 0)
+#  include <deal.II/lac/affine_constraints.h>
+#else
+#  include <deal.II/lac/constraint_matrix.h>
+namespace dealii
+{
+  template <typename Number>
+  struct ConstraintsHelper;
+
+  template <>
+  struct ConstraintsHelper<double>
+  {
+    using type = ConstraintMatrix;
+  };
+
+  template <typename Number>
+  using AffineConstraints = typename ConstraintsHelper<Number>::type;
+} // namespace dealii
+#endif
 
 #include <deal.II/numerics/vector_tools.h>
 

--- a/include/deal2lkit/parsed_zero_average_constraints.h
+++ b/include/deal2lkit/parsed_zero_average_constraints.h
@@ -23,7 +23,27 @@
 
 #include <deal.II/fe/component_mask.h>
 
-#include <deal.II/lac/affine_constraints.h>
+// old versions of dealii use ConstraintMatrix but the new versions
+// have switched to AffineConstraints<double>
+#if DEAL_II_VERSION_GTE(9, 1, 0)
+#  include <deal.II/lac/affine_constraints.h>
+#else
+#  include <deal.II/lac/constraint_matrix.h>
+namespace dealii
+{
+  template <typename Number>
+  struct ConstraintsHelper;
+
+  template <>
+  struct ConstraintsHelper<double>
+  {
+    using type = ConstraintMatrix;
+  };
+
+  template <typename Number>
+  using AffineConstraints = typename ConstraintsHelper<Number>::type;
+} // namespace dealii
+#endif
 
 #include <deal2lkit/config.h>
 #include <deal2lkit/parameter_acceptor.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_05.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_05.cc
@@ -32,7 +32,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_06.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_06.cc
@@ -31,7 +31,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_07.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_07.cc
@@ -32,7 +32,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_08.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_08.cc
@@ -33,7 +33,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_09.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_09.cc
@@ -32,7 +32,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_10.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_10.cc
@@ -32,7 +32,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>

--- a/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_11.cc
+++ b/tests/parsed_dirichlet_bcs/parsed_dirichlet_bcs_11.cc
@@ -30,7 +30,6 @@
 
 #include <deal.II/grid/grid_generator.h>
 
-#include <deal.II/lac/affine_constraints.h>
 #include <deal.II/lac/vector.h>
 
 #include <deal.II/numerics/vector_tools.h>


### PR DESCRIPTION
In order to keep backward compatibility with deal.II verision 9.0, some not-so-beautiful workarounds seem to be necessary.